### PR TITLE
Integrate recalculate filters

### DIFF
--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -8,25 +8,34 @@
 			YoastSEO.app.registerPlugin('yoastACFAnalysis', {status: 'ready'});
 			YoastSEO.app.registerModification('content', this.addAcfFieldsToContent, 'yoastACFAnalysis', 5);
 
+			this.analysisTimeout = 0;
+
 			// Re-analyse SEO score each time the content of an ACF field is updated
-			$('#post-body').find('input[type=text][name^=acf], textarea[name^=acf]').on('keyup paste cut', function() {
-				YoastSEO.app.pluginReloaded('yoastACFAnalysis');
+			$('#post-body').find('input[type=text][id^=acf], textarea[id^=acf-]').on('keyup paste cut blur', function() {
+				if ( YoastACFAnalysis.analysisTimeout ) {
+					window.clearTimeout(YoastACFAnalysis.analysisTimeout);
+				}
+
+				YoastACFAnalysis.analysisTimeout = window.setTimeout( function() { YoastSEO.app.pluginReloaded('yoastACFAnalysis'); }, 200 );
 			});
-		}
+
+		};
 
 		/**
-		 * Combine the  content of all ACF fields on the page and add it to Yoast content analysis 
+		 * Combine the content of all ACF fields on the page and add it to Yoast content analysis
 		 *
 		 * @param data Current page content
 		 */
 		YoastACFAnalysis.prototype.addAcfFieldsToContent = function(data) {
-			var acf_content = '';
+			var acf_content = ' ';
 			
-			$('#post-body').find('input[type=text][name^=acf], textarea[name^=acf]').each(function() {
+			$('#post-body').find('input[type=text][id^=acf], textarea[id^=acf-]').each(function() {
 				acf_content += ' ' + $(this).val();
 			});
 
-			return data + acf_content;
+			data = data + acf_content;
+
+			return data.trim();
 		};
 
 		new YoastACFAnalysis();

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -11,7 +11,7 @@
 			this.analysisTimeout = 0;
 
 			// Re-analyse SEO score each time the content of an ACF field is updated
-			$('#post-body').find('input[type=text][id^=acf], textarea[id^=acf-]').on('keyup paste cut blur', function() {
+			$('#post-body, #edittag').find('input[type=text][id^=acf], textarea[id^=acf-]').on('keyup paste cut blur', function() {
 				if ( YoastACFAnalysis.analysisTimeout ) {
 					window.clearTimeout(YoastACFAnalysis.analysisTimeout);
 				}
@@ -29,7 +29,7 @@
 		YoastACFAnalysis.prototype.addAcfFieldsToContent = function(data) {
 			var acf_content = ' ';
 			
-			$('#post-body').find('input[type=text][id^=acf], textarea[id^=acf-]').each(function() {
+			$('#post-body, #edittag').find('input[type=text][id^=acf], textarea[id^=acf-]').each(function() {
 				acf_content += ' ' + $(this).val();
 			});
 

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -11,14 +11,19 @@
 			this.analysisTimeout = 0;
 
 			// Re-analyse SEO score each time the content of an ACF field is updated
-			$('#post-body, #edittag').find('input[type=text][id^=acf], textarea[id^=acf-]').on('keyup paste cut blur', function() {
+			$(document).on('acf/setup_fields', this.bindListeners);
+		};
+
+		/**
+		 * Bind listeners to text fields (input and textarea)
+		 */
+		YoastACFAnalysis.prototype.bindListeners = function() {
+			$('#post-body, #edittag').find('input[type=text][id^=acf], textarea[id^=acf]').on('keyup paste cut blur', function() {
 				if ( YoastACFAnalysis.analysisTimeout ) {
 					window.clearTimeout(YoastACFAnalysis.analysisTimeout);
 				}
-
 				YoastACFAnalysis.analysisTimeout = window.setTimeout( function() { YoastSEO.app.pluginReloaded('yoastACFAnalysis'); }, 200 );
 			});
-
 		};
 
 		/**
@@ -29,7 +34,7 @@
 		YoastACFAnalysis.prototype.addAcfFieldsToContent = function(data) {
 			var acf_content = ' ';
 			
-			$('#post-body, #edittag').find('input[type=text][id^=acf], textarea[id^=acf-]').each(function() {
+			$('#post-body, #edittag').find('input[type=text][id^=acf], textarea[id^=acf]').each(function() {
 				acf_content += ' ' + $(this).val();
 			});
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,4 +14,4 @@ Adds the content of all ACF fields to the Yoast SEO score analysis.
 
 This had previously been done by the [WordPress SEO ACF Content Analysis](https://wordpress.org/plugins/wp-seo-acf-content-analysis/) plugin but that no longer works with Yoast 3.0. Kudos to [ryuheixys](https://profiles.wordpress.org/ryuheixys/), the author of that plugin, for the original idea.
 
-Please note that this does not work with the \"Recalculate SEO scores\" tool in Yoast SEO\'s admin area. I am [looking into that](https://github.com/Yoast/wordpress-seo/issues/3323#issuecomment-160114155).
+Please note that this does not work with the "Recalculate SEO scores" tool in Yoast WordPress SEO's admin area. I am [looking into that](https://github.com/Yoast/wordpress-seo/issues/3323#issuecomment-160114155).

--- a/readme.txt
+++ b/readme.txt
@@ -13,5 +13,3 @@ Adds the content of all ACF fields to the Yoast SEO score analysis.
 [Yoast SEO\'s](https://yoast.com/wordpress/plugins/) score analysis does not take in to account the content of a post\'s [Advanced Custom Fields](http://www.advancedcustomfields.com/). This plugin uses Yoast 3.0\'s plugin system to hook into the analyser in order to add ACF content to the SEO analysis.
 
 This had previously been done by the [WordPress SEO ACF Content Analysis](https://wordpress.org/plugins/wp-seo-acf-content-analysis/) plugin but that no longer works with Yoast 3.0. Kudos to [ryuheixys](https://profiles.wordpress.org/ryuheixys/), the author of that plugin, for the original idea.
-
-Please note that this does not work with the \"Recalculate SEO scores\" tool in Yoast SEO\'s admin area. I am [looking into that](https://github.com/Yoast/wordpress-seo/issues/3323#issuecomment-160114155).

--- a/readme.txt
+++ b/readme.txt
@@ -10,6 +10,6 @@ License URI: http://www.gnu.org/licenses/gpl.html
 Adds the content of all ACF fields to the Yoast SEO score analysis.
 
 == Description ==
-[Yoast SEO\'s](https://yoast.com/wordpress/plugins/) score analysis does not take in to account the content of a post\'s [Advanced Custom Fields](http://www.advancedcustomfields.com/). This plugin uses Yoast 3.0\'s plugin system to hook into the analyser in order to add ACF content to the SEO analysis.
+[Yoast WordPress SEO's](https://yoast.com/wordpress/plugins/) score analysis does not take in to account the content of a post's [Advanced Custom Fields](http://www.advancedcustomfields.com/). This plugin uses Yoast WordPress SEO 3.1's plugin system to hook into the analyser in order to add ACF content to the SEO analysis.
 
 This had previously been done by the [WordPress SEO ACF Content Analysis](https://wordpress.org/plugins/wp-seo-acf-content-analysis/) plugin but that no longer works with Yoast 3.0. Kudos to [ryuheixys](https://profiles.wordpress.org/ryuheixys/), the author of that plugin, for the original idea.

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -3,7 +3,7 @@
  * Plugin Name: Yoast ACF Analysis
  * Plugin URI: https://forsberg.ax
  * Description: Adds the content of all ACF fields to the Yoast SEO score analysis.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Marcus Forsberg
  * Author URI: https://forsberg.ax
  * License: GPL v3
@@ -87,7 +87,7 @@ class Yoast_ACF_Analysis {
 	 * Notify that we need ACF to be installed and active.
 	 */
 	public function acf_not_active_notification() {
-		$message = __( 'ACF Yoast Analysis requires Advanced Custom Fields (free or pro) to be installed and activated.', 'wordpress-seo' );
+		$message = __( 'ACF Yoast Analysis requires Advanced Custom Fields (free or pro) to be installed and activated.', 'yoast-acf-analysis' );
 
 		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );
 	}
@@ -96,7 +96,7 @@ class Yoast_ACF_Analysis {
 	 * Notify that we need WordPress SEO to be installed and active.
 	 */
 	public function wordpress_seo_requirements_not_met() {
-		$message = __( 'ACF Yoast Analysis requires Yoast SEO 3.0+ to be installed and activated.', 'wordpress-seo' );
+		$message = __( 'ACF Yoast Analysis requires Yoast SEO 3.0+ to be installed and activated.', 'yoast-acf-analysis' );
 
 		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );
 	}

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -57,7 +57,7 @@ class Yoast_ACF_Analysis {
 			}
 			else {
 				// Compare if version is >= 3.0
-				if ( defined('WPSEO_VERSION') ) {
+				if ( defined( 'WPSEO_VERSION' ) ) {
 					if ( version_compare( substr( WPSEO_VERSION, 0, 3 ), '3.0', '<' ) ) {
 						add_action( 'admin_notices', array( $this, 'wordpress_seo_requirements_not_met' ) );
 						$deactivate = true;
@@ -147,11 +147,19 @@ class Yoast_ACF_Analysis {
 		}
 
 		$post_acf_fields = get_fields( $post->ID );
-		$acf_content = $this->get_field_data( $post_acf_fields );
+		$acf_content     = $this->get_field_data( $post_acf_fields );
 
 		return trim( $content . ' ' . $acf_content );
 	}
 
+	/**
+	 * Add custom fields to term content
+	 *
+	 * @param string  $content String of the content to add data to.
+	 * @param WP_Term $term    The term to get the custom ffields of.
+	 *
+	 * @return string Content with added ACF data.
+	 */
 	public function add_recalculation_data_to_term_content( $content, $term ) {
 		// ACF defines this function.
 		if ( ! function_exists( 'get_fields' ) ) {
@@ -163,7 +171,7 @@ class Yoast_ACF_Analysis {
 		}
 
 		$term_acf_fields = get_fields( $term->taxonomy . '_' . $term->term_id );
-		$acf_content = $this->get_field_data( $term_acf_fields );
+		$acf_content     = $this->get_field_data( $term_acf_fields );
 
 		return trim( $content . ' ' . $acf_content );
 	}
@@ -191,15 +199,12 @@ class Yoast_ACF_Analysis {
 				case 'array':
 					if ( isset( $field['sizes']['thumbnail'] ) ) {
 						// Put all images in img tags for scoring.
-						$alt = ( isset( $field['alt'] ) ) ? $field['alt'] : '';
+						$alt   = ( isset( $field['alt'] ) ) ? $field['alt'] : '';
 						$title = ( isset( $field['title'] ) ) ? $field['title'] : '';
 
 						$output .= ' <img src="' . esc_url( $field['sizes']['thumbnail'] ) . '" alt="' . esc_attr( $alt ) . '" title="' . esc_attr( $title ) . '" />';
 					}
 					else {
-
-						// formatting
-
 						$output .= ' ' . $this->get_field_data( $field );
 					}
 

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -8,57 +8,178 @@
  * Author URI: https://forsberg.ax
  * License: GPL v3
  */
- 
-if(! defined('ABSPATH')) exit;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Yoast_ACF_Analysis
+ *
+ * Adds ACF data to the content analyses of WordPress SEO
+ *
+ */
 class Yoast_ACF_Analysis {
 	private $plugin_data = null;
-	
-	function __construct() {
-		add_action('admin_init', array($this, 'admin_init'));
-		add_filter('admin_enqueue_scripts', array($this, 'enqueue_scripts'));
-	}
-	
-	public function admin_init() {
-		$this->plugin_data = get_plugin_data(dirname(__FILE__));
-		
-		// Require ACF and Yoast
-		if (current_user_can('activate_plugins')) {
-			$deactivate = false;
-			
-			// ACF
-			if(!is_plugin_active('advanced-custom-fields/acf.php') && !is_plugin_active('advanced-custom-fields-pro/acf.php')) {
-				add_action('admin_notices', array($this, 'require_acf'));
-				$deactivate = true;
-			}
-			
-			// Yoast
-			if(!is_plugin_active('wordpress-seo/wp-seo.php') && !is_plugin_active('wordpress-seo-premium/wp-seo-premium.php')) {
-				add_action('admin_notices', array($this, 'require_yoast'));
-				$deactivate = true;
-			}
-			
-			if($deactivate) {
-				deactivate_plugins(plugin_basename( __FILE__ )); 
 
-				if (isset($_GET['activate'])) {
-					unset($_GET['activate']);
+	/**
+	 * Yoast_ACF_Analysis constructor.
+	 *
+	 * Add hooks and filters.
+	 *
+	 */
+	function __construct() {
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
+
+		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_recalculation_data_to_content' ) );
+	}
+
+	/**
+	 * Add notifications to admin if plugins ACF or WordPress SEO are not present.
+	 */
+	public function admin_init() {
+
+		// Require ACF and Yoast
+		if ( current_user_can( 'activate_plugins' ) ) {
+			$deactivate = false;
+
+			// ACF
+			if ( ! is_plugin_active( 'advanced-custom-fields/acf.php' ) && ! is_plugin_active( 'advanced-custom-fields-pro/acf.php' ) ) {
+				add_action( 'admin_notices', array( $this, 'acf_not_active_notification' ) );
+				$deactivate = true;
+			}
+
+			// WordPress SEO
+			if ( ! is_plugin_active( 'wordpress-seo/wp-seo.php' ) && ! is_plugin_active( 'wordpress-seo-premium/wp-seo-premium.php' ) ) {
+				add_action( 'admin_notices', array( $this, 'wordpress_seo_requirements_not_met' ) );
+				$deactivate = true;
+			}
+			else {
+				// Compare if version is >= 3.0
+				if ( defined('WPSEO_VERSION') ) {
+					if ( version_compare( substr( WPSEO_VERSION, 0, 3 ), '3.0', '<' ) ) {
+						add_action( 'admin_notices', array( $this, 'wordpress_seo_requirements_not_met' ) );
+						$deactivate = true;
+					}
 				}
 			}
+
+			// Deactivate when we cannot do the job we are hired to do.
+			if ( $deactivate ) {
+				deactivate_plugins( plugin_basename( __FILE__ ) );
+
+				if ( isset( $_GET['activate'] ) ) {
+					unset( $_GET['activate'] );
+				}
+
+				return;
+			}
+
+			// Only enqueue when we are active.
+			add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+			$this->plugin_data = get_plugin_data( dirname( __FILE__ ) );
 		}
 	}
-	
-	public function require_acf() { ?>
-		<div class="error"><p>ACF Yoast Analysis requires Advanced Custom Fields (free or pro) to be installed and activated.</p></div><?php
+
+	/**
+	 * Notify that we need ACF to be installed and active.
+	 */
+	public function acf_not_active_notification() {
+		$message = __( 'ACF Yoast Analysis requires Advanced Custom Fields (free or pro) to be installed and activated.', 'wordpress-seo' );
+
+		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );
 	}
-	
-	public function require_yoast() { ?>
-		<div class="error"><p>ACF Yoast Analysis requires Yoast SEO 3.0+ to be installed and activated.</p></div><?php
+
+	/**
+	 * Notify that we need WordPress SEO to be installed and active.
+	 */
+	public function wordpress_seo_requirements_not_met() {
+		$message = __( 'ACF Yoast Analysis requires Yoast SEO 3.0+ to be installed and activated.', 'wordpress-seo' );
+
+		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );
 	}
-	
+
+	/**
+	 * Enqueue JavaScript file to feed data to Yoast Content Analyses.
+	 */
 	public function enqueue_scripts() {
-		wp_enqueue_script('yoast-acf-analysis', plugins_url('/js/yoast-acf-analysis.js', __FILE__), array('jquery', 'wp-seo-post-scraper'), $this->plugin_data['Version']);
+		wp_enqueue_script(
+			'yoast-acf-analysis',
+			plugins_url( '/js/yoast-acf-analysis.js', __FILE__ ),
+			array(
+				'jquery',
+				'wp-seo-post-scraper',
+			),
+			$this->plugin_data['Version']
+		);
+	}
+
+	/**
+	 * Add ACF data to post content
+	 *
+	 * @param string  $content String of the content to add data to.
+	 * @param WP_Post $post    Item the content belongs to.
+	 *
+	 * @return string Content with added ACF data.
+	 */
+	public function add_recalculation_data_to_content( $content, $post ) {
+		// ACF defines this function.
+		if ( ! function_exists( 'get_fields' ) ) {
+			return '';
+		}
+
+		if ( false === ( $post instanceof WP_Post ) ) {
+			return '';
+		}
+
+		$post_acf_fields = get_fields( $post->ID );
+		$acf_content = $this->get_field_data( $post_acf_fields );
+
+		return trim( $content . ' ' . $acf_content );
+	}
+
+	/**
+	 * Filter what ACF Fields not to score
+	 *
+	 * @param array $fields ACF Fields to parse.
+	 *
+	 * @return string Content of all ACF fields combined.
+	 */
+	function get_field_data( $fields ) {
+		$output = '';
+
+		if ( ! is_array( $fields ) ) {
+			return $output;
+		}
+
+		foreach ( $fields as $key => $field ) {
+			switch ( gettype( $field ) ) {
+				case 'string':
+					$output .= ' ' . $field;
+					break;
+
+				case 'array':
+					if ( isset( $field['sizes']['thumbnail'] ) ) {
+						// Put all images in img tags for scoring.
+						$alt = ( isset( $field['alt'] ) ) ? $field['alt'] : '';
+						$title = ( isset( $field['title'] ) ) ? $field['title'] : '';
+
+						$output .= ' <img src="' . esc_url( $field['sizes']['thumbnail'] ) . '" alt="' . esc_attr( $alt ) . '" title="' . esc_attr( $title ) . '" />';
+					}
+					else {
+
+						// formatting
+
+						$output .= ' ' . $this->get_field_data( $field );
+					}
+
+					break;
+			}
+		}
+
+		return trim( $output );
 	}
 }
- 
+
 new Yoast_ACF_Analysis();

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://forsberg.ax
  * Description: Adds the content of all ACF fields to the Yoast SEO score analysis.
  * Version: 1.1.0
- * Author: Marcus Forsberg
+ * Author: Marcus Forsberg & Team Yoast
  * Author URI: https://forsberg.ax
  * License: GPL v3
  */
@@ -28,13 +28,15 @@ class Yoast_ACF_Analysis {
 	 * Yoast_ACF_Analysis constructor.
 	 *
 	 * Add hooks and filters.
-	 *
 	 */
 	function __construct() {
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
 		add_filter( 'wpseo_post_content_for_recalculation', array( $this, 'add_recalculation_data_to_post_content' ) );
-		add_filter( 'wpseo_term_description_for_recalculation', array( $this, 'add_recalculation_data_to_term_content' ) );
+		add_filter( 'wpseo_term_description_for_recalculation', array(
+			$this,
+			'add_recalculation_data_to_term_content'
+		) );
 	}
 
 	/**
@@ -52,7 +54,7 @@ class Yoast_ACF_Analysis {
 				$deactivate = true;
 			}
 
-			// WordPress SEO
+			// Yoast SEO for WordPress
 			if ( ! is_plugin_active( 'wordpress-seo/wp-seo.php' ) && ! is_plugin_active( 'wordpress-seo-premium/wp-seo-premium.php' ) ) {
 				add_action( 'admin_notices', array( $this, 'wordpress_seo_requirements_not_met' ) );
 				$deactivate = true;
@@ -60,7 +62,7 @@ class Yoast_ACF_Analysis {
 			else {
 				// Compare if version is >= 3.0
 				if ( defined( 'WPSEO_VERSION' ) ) {
-					if ( version_compare( substr( WPSEO_VERSION, 0, 3 ), '3.0', '<' ) ) {
+					if ( version_compare( substr( WPSEO_VERSION, 0, 3 ), '3.1', '<' ) ) {
 						add_action( 'admin_notices', array( $this, 'wordpress_seo_requirements_not_met' ) );
 						$deactivate = true;
 					}
@@ -95,10 +97,10 @@ class Yoast_ACF_Analysis {
 	}
 
 	/**
-	 * Notify that we need WordPress SEO to be installed and active.
+	 * Notify that we need Yoast SEO for WordPress to be installed and active.
 	 */
 	public function wordpress_seo_requirements_not_met() {
-		$message = __( 'ACF Yoast Analysis requires Yoast SEO 3.0+ to be installed and activated.', 'yoast-acf-analysis' );
+		$message = __( 'ACF Yoast Analysis requires Yoast SEO for WordPress 3.1+ to be installed and activated.', 'yoast-acf-analysis' );
 
 		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );
 	}
@@ -185,7 +187,7 @@ class Yoast_ACF_Analysis {
 	 *
 	 * @return string Content of all ACF fields combined.
 	 */
-	function get_field_data( $fields ) {
+	private function get_field_data( $fields ) {
 		$output = '';
 
 		if ( ! is_array( $fields ) ) {
@@ -201,10 +203,8 @@ class Yoast_ACF_Analysis {
 				case 'array':
 					if ( isset( $field['sizes']['thumbnail'] ) ) {
 						// Put all images in img tags for scoring.
-						$alt   = ( isset( $field['alt'] ) ) ? $field['alt'] : '';
-						$title = ( isset( $field['title'] ) ) ? $field['title'] : '';
-
-						$output .= ' <img src="' . esc_url( $field['sizes']['thumbnail'] ) . '" alt="' . esc_attr( $alt ) . '" title="' . esc_attr( $title ) . '" />';
+						$alt = ( isset( $field['alt'] ) ) ? $field['alt'] : '';
+						$output .= ' <img src="' . esc_url( $field['sizes']['thumbnail'] ) . '" alt="' . esc_attr( $alt ) . '" />';
 					}
 					else {
 						$output .= ' ' . $this->get_field_data( $field );

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -20,6 +20,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  */
 class Yoast_ACF_Analysis {
+
+	/** @var array Plugin information. */
 	private $plugin_data = null;
 
 	/**


### PR DESCRIPTION
Integrated recalculation filters (WordPress SEO 3.1).
Also applied Yoast code styles and added documentation.

Post and Term ACF fields are being added to the content in JavaScript and to the recalculation algorithms.

What does not work yet: wysiwyg ACF fields are not updated in JavaScript yet.
This will be a new issue.