### PR TITLE
Fix js syntax errors for jQuery 1.12 which was included with WP 4.5.

### DIFF
--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -18,7 +18,7 @@
 		 * Bind listeners to text fields (input and textarea)
 		 */
 		YoastACFAnalysis.prototype.bindListeners = function() {
-			$('#post-body, #edittag').find('input[type=text][id^=acf], textarea[id^=acf]').on('keyup paste cut blur', function() {
+			$('#post-body, #edittag').find('input[type="text"][id^="acf"], textarea[id^="acf"]').on('keyup paste cut blur', function() {
 				if ( YoastACFAnalysis.analysisTimeout ) {
 					window.clearTimeout(YoastACFAnalysis.analysisTimeout);
 				}
@@ -34,7 +34,7 @@
 		YoastACFAnalysis.prototype.addAcfFieldsToContent = function(data) {
 			var acf_content = ' ';
 			
-			$('#post-body, #edittag').find('input[type=text][id^=acf], textarea[id^=acf]').each(function() {
+			$('#post-body, #edittag').find('input[type="text"][id^="acf"], textarea[id^="acf"]').each(function() {
 				acf_content += ' ' + $(this).val();
 			});
 


### PR DESCRIPTION
In effect this plugin has been broken since WP 4.5 came out. This minor change fixes that.

References:
https://make.wordpress.org/core/2016/03/29/jquery-updates-in-wordpress-4-5/
https://wordpress.org/support/topic/read-this-first-wordpress-45-master-list?replies=7#post-8271654