### PR TITLE
Avoid social share blank screen when using Yoast SEO Premium.

### DIFF
--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -127,7 +127,8 @@ class Yoast_ACF_Analysis {
 					'jquery',
 					$script_prefix . '-post-scraper',
 				),
-				self::VERSION
+				self::VERSION,
+				true
 			);
 		}
 
@@ -140,7 +141,8 @@ class Yoast_ACF_Analysis {
 					'jquery',
 					$script_prefix . '-term-scraper',
 				),
-				self::VERSION
+				self::VERSION,
+				true
 			);
 		}
 	}


### PR DESCRIPTION
Using Yoast SEO premium and this plugin results in blank tabs for social sharing. Enqueuing scripts in the footer fixes this issue.