### PR TITLE
Introduce messages to inform the user about deprecation

### DIFF
--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -49,52 +49,106 @@ class Yoast_ACF_Analysis {
 
 		$notice_functions = array();
 
-		// Check for: Yoast SEO for WordPress.
-		if ( defined( 'WPSEO_VERSION' ) ) {
-			// Make sure that version is >= 3.1
-			if ( version_compare( substr( WPSEO_VERSION, 0, 3 ), '3.1', '<' ) ) {
-				$notice_functions[] = 'wordpress_seo_requirements_not_met';
+		// Check if the AC plugin is active.
+		$recommended_plugin_is_active = defined( 'AC_SEO_ACF_ANALYSIS_PLUGIN_NAME' ) && is_plugin_active( plugin_basename( AC_SEO_ACF_ANALYSIS_PLUGIN_NAME ) );
+
+		// Check if the user has the ability to manage plugins.
+		$user_can_activate_plugins = current_user_can( 'activate_plugins' );
+
+		// Depending on user-plugin-activation rights, show a certain message.
+		if ( $user_can_activate_plugins ) {
+			// Tell the user this plugin can be deactivated.
+			if ( $recommended_plugin_is_active ) {
+				$notice_functions[] = 'notification_deactivate_plugin';
+			}
+
+			// Tell the user to get the plugin and activate it
+			if ( ! $recommended_plugin_is_active ) {
+				$notice_functions[] = 'notification_install_and_activate';
 			}
 		}
-		else  {
-			$notice_functions[] = 'wordpress_seo_requirements_not_met';
+
+		if ( ! $user_can_activate_plugins ) {
+			// Tell the user a better plugin is available, suggest to contact the person who maintains the website.
+			$notice_functions[] = 'notification_contact_site_administrator';
 		}
+
+		// Check for: Yoast SEO for WordPress.
+		// Make sure that version is >= 3.1
+		$requirements_met = ( defined( 'WPSEO_VERSION' ) && version_compare( substr( WPSEO_VERSION, 0, 3 ), '3.1', '>=' ) );
 
 		// Check for: ACF.
-		if ( ! class_exists( 'acf' ) && ! is_plugin_active( 'advanced-custom-fields-pro/acf.php' ) ) {
-			$notice_functions[] = 'acf_not_active_notification';
-		}
+		$requirements_met = class_exists( 'acf' ) && $requirements_met;
 
 		// Enqueue when no problems were found.
-		if ( empty( $notice_functions ) ) {
+		if ( ! $recommended_plugin_is_active && $requirements_met ) {
 			// Make sure we load very late to be able to check enqueue of scripts we depend on.
 			add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 999 );
 		}
-		else {
-			// Show notices to users who can act on them.
-			if ( current_user_can( 'activate_plugins' ) ) {
-				$this->show_notices( $notice_functions );
 
-				// Deactivate this plugin if we are not a mu-plugin.
-				if ( is_plugin_active( plugin_basename( YOAST_ACF_ANALYSIS_FILE ) ) ) {
-					$this->deactivate();
-				}
-			}
+		// Show notices.
+		if ( ! empty( $notice_functions ) ) {
+			$this->show_notices( $notice_functions );
 		}
+	}
+
+	/**
+	 * Shows a notification to inform the user that this plugin can be deactivated and removed.
+	 */
+	public function notification_deactivate_plugin() {
+		$message = sprintf(
+		/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO, %2$s resolves to Yoast SEO: ACF Analysis */
+			__( 'As you have installed and activated the %1$s plugin, you can now safely <strong>deactivate and remove</strong> the %2$s plugin.', 'yoast-acf-analysis' ),
+			'<strong>ACF Content Analysis for Yoast SEO</strong>',
+			'<strong>Yoast SEO: ACF Analysis</strong>'
+		);
+
+		$this->display_notification( $message );
+	}
+
+	/**
+	 * Shows a notification to inform the user to install and activate the AC plugin.
+	 */
+	public function notification_install_and_activate() {
+		$message = $this->get_general_deprecation_message();
+		$message .= sprintf(
+		/* translators: %1$s resolves to an openen link tag to search the plugin repository, %2$s resolves to the closing link tag, %3$s resolves to ACF Content Analysis for Yoast SEO, %4$s resolves to Angry Creative */
+			__( 'Please install & activate %1$s%3$s%2$s by %4$s to recieve an even better integration.', 'yoast-acf-analysis' ),
+			'<a href="' . esc_url( admin_url( 'plugin-install.php?tab=search&type=term&s=acf-content-analysis-for-yoast-seo&plugin-search-input=Search+Plugins' ) ) . '">',
+			'</a>',
+			'ACF Content Analysis for Yoast SEO',
+			'Angry Creative'
+		);
+
+		$this->display_notification( $message );
+	}
+
+	/**
+	 * Shows a notification for a crippled user to contact a website administrator.
+	 */
+	public function notification_contact_site_administrator() {
+		$message = $this->get_general_deprecation_message();
+		$message .= sprintf(
+		/* translators: %1$s resolves to a link to ACF Content Analysis for Yoast SEO on WordPress.org, %2$s resolves to Yoast SEO: ACF Analysis */
+			__( 'Please contact your website administrator to have the %1$s plugin installed and the %2$s plugin removed.', 'yoast-acf-analysis' ),
+			'<a href="https://wordpress.org/plugins/acf-content-analysis-for-yoast-seo/" target="_blank">ACF Content Analysis for Yoast SEO</a>',
+			'<strong>Yoast SEO: ACF Analysis</strong>'
+		);
+
+		$this->display_notification( $message );
 	}
 
 	/**
 	 * Notify that we need ACF to be installed and active.
 	 */
 	public function acf_not_active_notification() {
-
 		$message = sprintf(
 			__( 'Please %1$sinstall & activate Advanced Custom Fields%2$s to use Yoast SEO: ACF Analysis.', 'yoast-acf-analysis' ),
 			'<a href="' . esc_url( admin_url( 'plugin-install.php?tab=search&type=term&s=advanced+custom+fields&plugin-search-input=Search+Plugins' ) ) . '">',
 			'</a>'
 		);
 
-		printf( '<div class="error"><p>%s</p></div>', $message );
+		$this->display_notification( $message );
 	}
 
 	/**
@@ -107,7 +161,7 @@ class Yoast_ACF_Analysis {
 			'</a>'
 		);
 
-		printf( '<div class="error"><p>%s</p></div>', $message );
+		$this->display_notification( $message );
 	}
 
 	/**
@@ -218,10 +272,9 @@ class Yoast_ACF_Analysis {
 				case 'array':
 					if ( isset( $field['sizes']['thumbnail'] ) ) {
 						// Put all images in img tags for scoring.
-						$alt = ( isset( $field['alt'] ) ) ? $field['alt'] : '';
+						$alt    = ( isset( $field['alt'] ) ) ? $field['alt'] : '';
 						$output .= ' <img src="' . esc_url( $field['sizes']['thumbnail'] ) . '" alt="' . esc_attr( $alt ) . '" />';
-					}
-					else {
+					} else {
 						$output .= ' ' . $this->get_field_data( $field );
 					}
 
@@ -244,6 +297,16 @@ class Yoast_ACF_Analysis {
 	}
 
 	/**
+	 * Displays the notification
+	 *
+	 * @param string $message Message to display.
+	 * @param string $type    Optional. Type of message. Defaults to error.
+	 */
+	protected function display_notification( $message, $type = 'error' ) {
+		printf( '<div class="' . $type . '"><p>%s</p></div>', wpautop( $message ) );
+	}
+
+	/**
 	 * Deactivate this plugin
 	 */
 	private function deactivate() {
@@ -253,8 +316,7 @@ class Yoast_ACF_Analysis {
 		// Add to recently active plugins list.
 		if ( ! is_network_admin() ) {
 			update_option( 'recently_activated', array( $file => $_SERVER['REQUEST_TIME'] ) + (array) get_option( 'recently_activated' ) );
-		}
-		else {
+		} else {
 			update_site_option( 'recently_activated', array( $file => $_SERVER['REQUEST_TIME'] ) + (array) get_site_option( 'recently_activated' ) );
 		}
 
@@ -262,6 +324,23 @@ class Yoast_ACF_Analysis {
 		if ( isset( $_GET['activate'] ) ) {
 			unset( $_GET['activate'] );
 		}
+	}
+
+	/**
+	 * @return string
+	 */
+	private function get_general_deprecation_message() {
+		return sprintf(
+			__( 'In a joined effort to make software as good as possible, %1$s, %2$s and %3$s have combined forces to make one %4$s %5$s integration plugin to rule them all.
+This means that the plugin you are currently using is not going to be maintained anymore.
+
+', 'yoast-acf-analysis' ),
+			'Team Yoast',
+			'Thomas Kräftner',
+			'Angry Creative',
+			'ACF',
+			'Yoast'
+		);
 	}
 }
 

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -113,7 +113,7 @@ class Yoast_ACF_Analysis {
 		$message = $this->get_general_deprecation_message();
 		$message .= sprintf(
 		/* translators: %1$s resolves to an openen link tag to search the plugin repository, %2$s resolves to the closing link tag, %3$s resolves to ACF Content Analysis for Yoast SEO, %4$s resolves to Angry Creative */
-			__( 'Please install & activate %1$s%3$s%2$s by %4$s to recieve an even better integration.', 'yoast-acf-analysis' ),
+			__( 'Please install & activate %1$s%3$s%2$s to instantly get improved functionality.', 'yoast-acf-analysis' ),
 			'<a href="' . esc_url( admin_url( 'plugin-install.php?tab=search&type=term&s=acf-content-analysis-for-yoast-seo&plugin-search-input=Search+Plugins' ) ) . '">',
 			'</a>',
 			'ACF Content Analysis for Yoast SEO',
@@ -331,8 +331,8 @@ class Yoast_ACF_Analysis {
 	 */
 	private function get_general_deprecation_message() {
 		return sprintf(
-			__( 'In a joined effort to make software as good as possible, %1$s, %2$s and %3$s have combined forces to make one %4$s %5$s integration plugin to rule them all.
-This means that the plugin you are currently using is not going to be maintained anymore.
+			__( 'In an effort to make the best software possible, %1$s, %2$s and %3$s have joined forces to make one %4$s %5$s integration plugin to rule them all.
+This means that the plugin you are currently using will <strong>not be maintained</strong> anymore.
 
 ', 'yoast-acf-analysis' ),
 			'Team Yoast',


### PR DESCRIPTION
User who has no rights to manager plugins:
![screen shot 2017-08-02 at 14 29 31](https://user-images.githubusercontent.com/2005352/28875086-96dbf480-7794-11e7-8a8a-683cb4927107.png)

User who has rights to manage plugins:
![screen shot 2017-08-02 at 14 29 13](https://user-images.githubusercontent.com/2005352/28875087-96dc3562-7794-11e7-8db8-679f0665a1ab.png)

After installing the Angry Creative plugin, suggest to deactivate and remove this plugin:
![screen shot 2017-08-02 at 14 28 58](https://user-images.githubusercontent.com/2005352/28875088-96dcb488-7794-11e7-8a53-ca33e01b1ced.png)

I have chosen not to deactivate the plugin automatically, because it will still leave the plugin files in place. These should be removed for security reasons.

Fixes https://github.com/Yoast/yoast-acf-analysis/issues/28