### PR TITLE
Use the constants used in the AC plugin

### DIFF
--- a/inc/class-ac-yoast-acf-content-analysis.php
+++ b/inc/class-ac-yoast-acf-content-analysis.php
@@ -67,7 +67,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 	 */
 	public function boot_dev() {
 		$version = ( -1 === version_compare( get_option( 'acf_version' ), 5 ) ) ? '4' : '5';
-		require_once dirname( YOAST_ACF_ANALYSIS_FILE ) . '/tests/js/system/data/acf' . $version . '.php';
+		require_once dirname( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH ) . '/tests/js/system/data/acf' . $version . '.php';
 	}
 
 	/**

--- a/inc/class-ac-yoast-acf-content-analysis.php
+++ b/inc/class-ac-yoast-acf-content-analysis.php
@@ -5,7 +5,7 @@
  *
  * Adds ACF data to the content analyses of WordPress SEO.
  */
-class Yoast_ACF_Analysis {
+class AC_Yoast_SEO_ACF_Content_Analysis {
 
 	/**
 	 * Yoast_ACF_Analysis init.
@@ -30,7 +30,7 @@ class Yoast_ACF_Analysis {
 
 		$this->boot();
 
-		if ( defined( 'YOAST_ACF_ANALYSIS_ENVIRONMENT' ) && 'development' === YOAST_ACF_ANALYSIS_ENVIRONMENT ) {
+		if ( defined( 'AC_YOAST_ACF_ANALYSIS_ENVIRONMENT' ) && 'development' === AC_YOAST_ACF_ANALYSIS_ENVIRONMENT ) {
 			$this->boot_dev();
 		}
 

--- a/inc/class-yoast-acf-analysis-assets.php
+++ b/inc/class-yoast-acf-analysis-assets.php
@@ -13,7 +13,7 @@ class Yoast_ACF_Analysis_Assets {
 	 * Initialize.
 	 */
 	public function init() {
-		$this->plugin_data = get_plugin_data( dirname( YOAST_ACF_ANALYSIS_FILE ) );
+		$this->plugin_data = get_plugin_data( dirname( AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ) );
 
 		add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
@@ -31,7 +31,7 @@ class Yoast_ACF_Analysis_Assets {
 		if ( 'post.php' === $pagenow || 'post-new.php' === $pagenow ) {
 			wp_enqueue_script(
 				'yoast-acf-analysis-post',
-				plugins_url( '/js/yoast-acf-analysis.js', YOAST_ACF_ANALYSIS_FILE ),
+				plugins_url( '/js/yoast-acf-analysis.js', AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ),
 				array( 'jquery', 'yoast-seo-post-scraper', 'underscore' ),
 				$this->plugin_data['Version']
 			);
@@ -43,7 +43,7 @@ class Yoast_ACF_Analysis_Assets {
 		if ( 'term.php' === $pagenow ) {
 			wp_enqueue_script(
 				'yoast-acf-analysis-term',
-				plugins_url( '/js/yoast-acf-analysis.js', YOAST_ACF_ANALYSIS_FILE ),
+				plugins_url( '/js/yoast-acf-analysis.js', AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ),
 				array( 'jquery', 'yoast-seo-term-scraper' ),
 				$this->plugin_data['Version']
 			);

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Yoast ACF Analysis ===
-Contributors: kraftner, marcusforsberg, joostdevalk, atimmer, omarreiss, jipmoors
-Tags: yoast, seo, acf, advanced custom fields, analysis, search engine optimization, seo score
+Contributors: yoast, angrycreative, kraftner, marcusforsberg, viktorfroberg, joostdevalk, atimmer, jipmoors, theorboman
+Tags: Yoast, SEO, ACF, Advanced Custom Fields, analysis, Search Engine Optimization
 Requires at least: 4.3.1
-Tested up to: 4.7
+Tested up to: 4.8.1
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Version: 2.0.0-dev

--- a/tests/php/unit/AssetsTest.php
+++ b/tests/php/unit/AssetsTest.php
@@ -15,10 +15,10 @@ class AssetsTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testInitHook() {
-		define( 'YOAST_ACF_ANALYSIS_FILE', '/directory/file' );
+		define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_FILE', '/directory/file' );
 		Functions\expect( 'get_plugin_data' )
 			->once()
-			->with( dirname( YOAST_ACF_ANALYSIS_FILE ) )
+			->with( dirname( AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ) )
 			->andReturn( array( 'Version' => '1.0.0' ) );
 
 		$testee = new \Yoast_ACF_Analysis_Assets();

--- a/tests/php/unit/MainTest.php
+++ b/tests/php/unit/MainTest.php
@@ -18,7 +18,7 @@ class MainTest extends \PHPUnit_Framework_TestCase {
 
 		$registry->add( 'config', 'Invalid Config' );
 
-		$testee = new \Yoast_ACF_Analysis();
+		$testee = new \AC_Yoast_SEO_ACF_Content_Analysis();
 
 		Functions\expect('get_option')
 			->once()

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -5,14 +5,14 @@
 
 /*
 Plugin Name: ACF Content Analysis for Yoast SEO
-Plugin URI: http://angrycreative.se
-Description: Ensure that Yoast SEO analysize all ACF content including Flexible Content and Repeaters.
+Plugin URI: https://wordpress.org/plugins/acf-content-analysis-for-yoast-seo/
+Description: Ensure that Yoast SEO analyzes all Advanced Custom Fields 4 and 5 content including Flexible Content and Repeaters.
 Version: 2.0.0
-Author: Thomas Kräftner, ViktorFroberg, marol87, pekz0r, angrycreative & Team Yoast
+Author: Thomas Kräftner, ViktorFroberg, marol87, pekz0r, angrycreative, Team Yoast
 Author URI: http://angrycreative.se
 License: GPL v3
-* Text Domain: yoast-acf-analysis
- * Domain Path: /languages/
+Text Domain: yoast-acf-analysis
+Domain Path: /languages/
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -3,14 +3,15 @@
  * @package YoastACFAnalysis
  */
 
-/**
- * Plugin Name: Yoast SEO: ACF Analysis
- * Plugin URI: https://wordpress.org/plugins/yoast-seo-acf-analysis/
- * Description: WordPress plugin that adds the content of all ACF fields to the Yoast SEO score analysis.
- * Version: 2.0.0-dev
- * Author: Thomas Kräftner, Marcus Forsberg & Team Yoast
- * License: GPL v3
- * Text Domain: yoast-acf-analysis
+/*
+Plugin Name: ACF Content Analysis for Yoast SEO
+Plugin URI: http://angrycreative.se
+Description: Ensure that Yoast SEO analysize all ACF content including Flexible Content and Repeaters.
+Version: 2.0.0
+Author: Thomas Kräftner, ViktorFroberg, marol87, pekz0r, angrycreative & Team Yoast
+Author URI: http://angrycreative.se
+License: GPL v3
+* Text Domain: yoast-acf-analysis
  * Domain Path: /languages/
  */
 
@@ -18,22 +19,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! defined( 'YOAST_ACF_ANALYSIS_FILE' ) ) {
-	define( 'YOAST_ACF_ANALYSIS_FILE', __FILE__ );
+if ( ! defined( 'AC_SEO_ACF_ANALYSIS_PLUGIN_PATH' ) ) {
+	define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_SLUG', 'ac-yoast-seo-acf-content-analysis' );
+	define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_FILE', __FILE__ );
+	define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+	define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_URL', plugins_url( '', __FILE__ ) . '/' );
+	define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_NAME', untrailingslashit( plugin_basename( __FILE__ ) ) );
 }
 
-if ( is_file( dirname( YOAST_ACF_ANALYSIS_FILE ) . '/vendor/autoload_52.php' ) ) {
-	require dirname( YOAST_ACF_ANALYSIS_FILE ) . '/vendor/autoload_52.php';
+if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload_52.php' ) ) {
+	require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload_52.php';
 
-	$yoast_acf_analysis = new Yoast_ACF_Analysis();
-	$yoast_acf_analysis->init();
+	$ac_yoast_seo_acf_analysis = new AC_Yoast_SEO_ACF_Content_Analysis();
+	$ac_yoast_seo_acf_analysis->init();
 }
 
 /**
  * Loads translations.
  */
 function yoast_acf_analysis_load_textdomain() {
-	$plugin_path = str_replace( '\\', '/', dirname( YOAST_ACF_ANALYSIS_FILE ) );
+	$plugin_path = str_replace( '\\', '/', AC_SEO_ACF_ANALYSIS_PLUGIN_PATH );
 	$mu_path    = str_replace( '\\', '/', WPMU_PLUGIN_DIR );
 
 	if ( 0 === stripos( $plugin_path, $mu_path ) ) {
@@ -48,9 +53,9 @@ add_action( 'plugins_loaded', 'yoast_acf_analysis_load_textdomain' );
 /**
  * Triggers a message whenever the class is missing.
  */
-if ( ! class_exists( 'Yoast_ACF_Analysis' ) && is_admin() ) {
+if ( ! class_exists( 'AC_Yoast_SEO_ACF_Content_Analysis' ) && is_admin() ) {
 	/* translators: %1$s resolves to Yoast SEO: ACF Analysis */
-	$message = sprintf( __( '%1$s could not be loaded because of missing files.', 'yoast-acf-analysis' ), 'Yoast SEO: ACF Analysis' );
+	$message = sprintf( __( '%1$s could not be loaded because of missing files.', 'yoast-acf-analysis' ), 'ACF Content Analysis for Yoast SEO' );
 	add_action(
 		'admin_notices',
 		create_function( '', "echo '<div class=\"error\"><p>$message</p></div>';" )


### PR DESCRIPTION
Reusing constants and base-classname will provide better backwards-compatiblity

Fixes https://github.com/Yoast/yoast-acf-analysis/issues/27