### PR TITLE
Add support for replacement variables in the Snippet Window.

### DIFF
--- a/js/src/app.js
+++ b/js/src/app.js
@@ -37,6 +37,16 @@ App.prototype.bindListeners = function(){
             fields.on('change', _self.maybeRefresh.bind(_self) );
             fields.on('change', replaceVars.updateReplaceVars.bind(_self, collect, _self.replaceVars));
 
+            // Do not ignore Wysiwyg fields for the purpose of Replace Vars.
+            jQuery('textarea[id^=wysiwyg-acf]').on('change', replaceVars.updateReplaceVars.bind(_self, collect, _self.replaceVars));
+            if (YoastSEO.wp._tinyMCEHelper) {
+                jQuery('textarea[id^=wysiwyg-acf]').each( function () {
+                    YoastSEO.wp._tinyMCEHelper.addEventHandler(this.id, [ 'input', 'change', 'cut', 'paste' ],
+                        replaceVars.updateReplaceVars.bind(_self, collect, _self.replaceVars));
+                });
+            }
+
+
             //Also refresh on media close as attachment data might have changed
             wp.media.frame.on('close', _self.maybeRefresh.bind(_self) );
         });

--- a/js/src/app.js
+++ b/js/src/app.js
@@ -2,6 +2,7 @@
 var config = require( "./config/config.js" );
 var helper = require( "./helper.js" );
 var collect = require( "./collect/collect.js" );
+var replaceVars = require( "./replacevars.js" );
 
 var analysisTimeout = 0;
 
@@ -17,7 +18,9 @@ var App = function(){
 App.prototype.bindListeners = function(){
 
     if(helper.acf_version >= 5){
+        this.replaceVars = replaceVars.createReplaceVars(collect);
         acf.add_action('change remove append sortstop', this.maybeRefresh);
+        acf.add_action('change remove append sortstop', replaceVars.updateReplaceVars.bind(this, collect, this.replaceVars));
     }else{
         var fieldSelectors = config.fieldSelectors.slice(0);
 
@@ -27,10 +30,12 @@ App.prototype.bindListeners = function(){
         var _self = this;
 
         jQuery(document).on('acf/setup_fields', function(){
+            this.replaceVars = replaceVars.createReplaceVars(collect);
             var fields = jQuery('#post-body, #edittag').find(fieldSelectors.join(','));
             //This would cause faster updates while typing
             //fields.on('change input', _self.maybeRefresh.bind(_self) );
             fields.on('change', _self.maybeRefresh.bind(_self) );
+            fields.on('change', replaceVars.updateReplaceVars.bind(_self, collect, _self.replaceVars));
 
             //Also refresh on media close as attachment data might have changed
             wp.media.frame.on('close', _self.maybeRefresh.bind(_self) );

--- a/js/src/collect/collect.js
+++ b/js/src/collect/collect.js
@@ -8,12 +8,7 @@ var Collect = function(){
 
 };
 
-Collect.prototype.append = function(data){
-
-    if(config.debug){
-        console.log('Recalculate...' + new Date());
-    }
-
+Collect.prototype.getFieldData = function () {
     var field_data = this.filterBroken(this.filterBlacklist(this.getData()));
 
     var used_types = _.uniq(_.pluck(field_data, 'type'));
@@ -21,6 +16,17 @@ Collect.prototype.append = function(data){
     _.each(used_types, function(type){
         field_data = scraper_store.getScraper(type).scrape(field_data);
     });
+
+    return field_data
+};
+
+Collect.prototype.append = function(data){
+
+    if(config.debug){
+        console.log('Recalculate...' + new Date());
+    }
+
+    var field_data = this.getFieldData();
 
     _.each(field_data, function(field){
 

--- a/js/src/collect/collect.js
+++ b/js/src/collect/collect.js
@@ -17,7 +17,7 @@ Collect.prototype.getFieldData = function () {
         field_data = scraper_store.getScraper(type).scrape(field_data);
     });
 
-    return field_data
+    return field_data;
 };
 
 Collect.prototype.append = function(data){

--- a/js/src/collect/collect.js
+++ b/js/src/collect/collect.js
@@ -13,6 +13,11 @@ Collect.prototype.getFieldData = function () {
 
     var used_types = _.uniq(_.pluck(field_data, 'type'));
 
+    if(config.debug) {
+        console.log('Used types:')
+        console.log(used_types);
+    }
+
     _.each(used_types, function(type){
         field_data = scraper_store.getScraper(type).scrape(field_data);
     });
@@ -37,16 +42,11 @@ Collect.prototype.append = function(data){
     });
 
     if(config.debug){
-
-        console.log('Used types:')
-        console.log(used_types);
-
         console.log('Field data:')
         console.table(field_data);
 
         console.log('Data:')
         console.log(data);
-
     }
 
     return data;

--- a/js/src/replacevars.js
+++ b/js/src/replacevars.js
@@ -21,7 +21,9 @@ var createReplaceVars = function (collect) {
 
         replaceVars[field.name] = new ReplaceVar( '%%cf_'+field.name+'%%', content, { source: 'direct' } );
         YoastSEO.wp.replaceVarsPlugin.addReplacement( replaceVars[field.name] );
-        console.log("Created ReplaceVar for: ", field.name, " with: ", content, replaceVars[field.name]);
+        if (config.debug) {
+            console.log("Created ReplaceVar for: ", field.name, " with: ", content, replaceVars[field.name]);
+        }
     });
 
     return replaceVars;
@@ -41,7 +43,9 @@ var updateReplaceVars = function (collect, replace_vars) {
         var content = (field.type === 'wysiwyg') ? jQuery(jQuery.parseHTML(field.content)).text() : field.content;
 
         replaceVars[field.name].replacement = content;
-        console.log("Updated ReplaceVar for: ", field.name, " with: ", content, replaceVars[field.name]);
+        if (config.debug) {
+            console.log("Updated ReplaceVar for: ", field.name, " with: ", content, replaceVars[field.name]);
+        }
     });
 };
 

--- a/js/src/replacevars.js
+++ b/js/src/replacevars.js
@@ -1,0 +1,51 @@
+/* global _, jQuery, YoastSEO, YoastReplaceVarPlugin */
+
+var config = require( "./config/config.js" );
+
+var ReplaceVar = YoastReplaceVarPlugin.ReplaceVar;
+
+var createReplaceVars = function (collect) {
+    if (ReplaceVar === undefined) {
+        if (config.debug) {
+            console.log('Replacing ACF variables in the Snippet Window requires the latest version of wordpress-seo.');
+        }
+        return;
+    }
+
+    fieldData   = collect.getFieldData();
+    replaceVars = {}
+
+    _.each(fieldData, function(field) {
+        // Remove HTML tags using jQuery in case of a wysiwyg field.
+        var content = (field.type === 'wysiwyg') ? jQuery( jQuery.parseHTML( field.content) ).text() : field.content;
+
+        replaceVars[field.name] = new ReplaceVar( '%%cf_'+field.name+'%%', content, { source: 'direct' } );
+        YoastSEO.wp.replaceVarsPlugin.addReplacement( replaceVars[field.name] );
+        console.log("Created ReplaceVar for: ", field.name, " with: ", content, replaceVars[field.name]);
+    });
+
+    return replaceVars;
+};
+
+var updateReplaceVars = function (collect, replace_vars) {
+    if (ReplaceVar === undefined) {
+        if (config.debug) {
+            console.log('Replacing ACF variables in the Snippet Window requires the latest version of wordpress-seo.');
+        }
+        return;
+    }
+
+    fieldData   = collect.getFieldData();
+    _.each(fieldData, function(field) {
+        // Remove HTML tags using jQuery in case of a wysiwyg field.
+        var content = (field.type === 'wysiwyg') ? jQuery(jQuery.parseHTML(field.content)).text() : field.content;
+
+        replaceVars[field.name].replacement = content;
+        console.log("Updated ReplaceVar for: ", field.name, " with: ", content, replaceVars[field.name]);
+    });
+};
+
+module.exports = {
+    createReplaceVars: createReplaceVars,
+    updateReplaceVars: updateReplaceVars
+};

--- a/js/src/replacevars.js
+++ b/js/src/replacevars.js
@@ -4,6 +4,8 @@ var config = require( "./config/config.js" );
 
 var ReplaceVar = YoastReplaceVarPlugin.ReplaceVar;
 
+var supportedTypes = ['email', 'text', 'textarea', 'url', 'wysiwyg'];
+
 var createReplaceVars = function (collect) {
     if (ReplaceVar === undefined) {
         if (config.debug) {
@@ -12,7 +14,7 @@ var createReplaceVars = function (collect) {
         return;
     }
 
-    fieldData   = collect.getFieldData();
+    fieldData   = _.filter(collect.getFieldData(), function (field) { return _.contains(supportedTypes, field.type) });
     replaceVars = {}
 
     _.each(fieldData, function(field) {
@@ -37,7 +39,7 @@ var updateReplaceVars = function (collect, replace_vars) {
         return;
     }
 
-    fieldData   = collect.getFieldData();
+    fieldData = _.filter(collect.getFieldData(), function (field) { return _.contains(supportedTypes, field.type) });
     _.each(fieldData, function(field) {
         // Remove HTML tags using jQuery in case of a wysiwyg field.
         var content = (field.type === 'wysiwyg') ? jQuery(jQuery.parseHTML(field.content)).text() : field.content;

--- a/tests/js/system/helpers/replaceVars.js
+++ b/tests/js/system/helpers/replaceVars.js
@@ -1,0 +1,12 @@
+var logContains = require('./logContains');
+
+module.exports = function ( browser, fieldName, fieldValue ) {
+    browser.execute(function () { YoastSEO.app.snippetPreview.openEditor(); } );
+
+    browser.clearValue( '.js-snippet-editor-title' );
+    browser.setValue( '.js-snippet-editor-title', [ '%%cf_'+fieldName+'%%' , browser.Keys.TAB ] );
+
+    browser.pause( 3000 );
+
+    browser.expect.element('#snippet_title').text.to.contain( fieldValue );
+};

--- a/tests/js/system/helpers/simpleField.js
+++ b/tests/js/system/helpers/simpleField.js
@@ -13,4 +13,5 @@ module.exports = function( browser, selector ){
 
     browser.expect.element('#snippet_meta').text.to.contain( hash );
 
+    return hash;
 };

--- a/tests/js/system/nightwatch.json
+++ b/tests/js/system/nightwatch.json
@@ -32,7 +32,7 @@
             "--headless",
             "--disable-gpu",
             "--incognito",
-            "--window-size=1280,1024"
+            "--window-size=1280,4048"
           ]
         }
       }

--- a/tests/js/system/pages/WordPressHelper.js
+++ b/tests/js/system/pages/WordPressHelper.js
@@ -25,7 +25,7 @@ module.exports = {
                 this.waitForElementVisible('@submitButton', 5000);
                 //this.api.saveScreenshot('screenshots/login-' + (new Date()).getTime() + '.png');
                 this.click('@submitButton');
-                return this.waitForElementVisible('#adminmenu #menu-dashboard.current', 15000);
+                return this.waitForElementVisible('#adminmenu #menu-dashboard .current', 15000);
             },
             newPost: function(){
                 this.api.url( this.api.launchUrl + '/wp/wp-admin/post-new.php' );

--- a/tests/js/system/tests/acf5/basic.js
+++ b/tests/js/system/tests/acf5/basic.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var simpleField = require('../../helpers/simpleField');
+var replaceVars = require('../../helpers/replaceVars');
 
 module.exports = {
     tags: ['acf5', 'basic'],
@@ -13,7 +14,8 @@ module.exports = {
     },
 
     'URL Field' : function (browser) {
-        simpleField( browser, '.field_type-url input, .acf-field-url input' );
+        var value = simpleField( browser, '.field_type-url input, .acf-field-url input' );
+        replaceVars( browser, 'yoast_acf_analysis_url', value );
     },
 
     after : function(browser) {

--- a/tests/js/system/tests/general/basic.js
+++ b/tests/js/system/tests/general/basic.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var logContains = require('../../helpers/logContains');
 var dummyContent = require('../../helpers/dummyContent');
 var simpleField = require('../../helpers/simpleField');
+var replaceVars = require('../../helpers/replaceVars');
 
 module.exports = {
     tags: ['acf4', 'acf5', 'basic'],
@@ -15,7 +16,8 @@ module.exports = {
     },
 
     'Text Field' : function (browser) {
-        simpleField(browser, '.field_type-text input, .acf-field-text input');
+        var value = simpleField(browser, '.field_type-text input, .acf-field-text input');
+        replaceVars( browser, 'yoast_acf_analysis_text', value );
     },
 
     'Text Field (as Headline)' : function (browser) {
@@ -50,11 +52,13 @@ module.exports = {
     },
 
     'Textarea Field' : function (browser) {
-        simpleField( browser, '.field_type-textarea textarea, .acf-field-textarea textarea' );
+        var value = simpleField( browser, '.field_type-textarea textarea, .acf-field-textarea textarea' );
+        replaceVars( browser, 'yoast_acf_analysis_textarea', value );
     },
 
     'Email Field' : function (browser) {
-        simpleField( browser, '.field_type-email input, .acf-field-email input' );
+        var value = simpleField( browser, '.field_type-email input, .acf-field-email input' );
+        replaceVars( browser, 'yoast_acf_analysis_email', value );
     },
 
     after : function(browser) {

--- a/tests/js/system/tests/general/content.js
+++ b/tests/js/system/tests/general/content.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var logContains = require('../../helpers/logContains');
 var dummyContent = require('../../helpers/dummyContent');
+var replaceVars = require('../../helpers/replaceVars');
 
 module.exports = {
     tags: ['acf4', 'acf5', 'content'],
@@ -43,6 +44,7 @@ module.exports = {
 
         browser.expect.element('#snippet_meta').text.to.contain( hash );
 
+        replaceVars( browser, 'yoast_acf_analysis_wysiwyg', hash );
     },
 
     'Image Field': function (browser) {
@@ -65,6 +67,12 @@ module.exports = {
                 browser.click('.acf-field-image .acf-button');
             }
         });
+
+        // Open Media Library
+        browser.useXpath();
+        browser.waitForElementVisible("//div[contains(@class, 'media-modal')]//a[@class='media-menu-item' and text()='Media Library']", 10000);
+        browser.click("//div[contains(@class, 'media-modal')]//a[@class='media-menu-item' and text()='Media Library']");
+        browser.useCss();
 
         // Select Attachment
         browser.waitForElementVisible('.media-modal .attachment', 10000);


### PR DESCRIPTION
Allows usage of fields added by ACF in the Snippet Window.

The fields can be used with %%cf_{name-of-custom-field}%%

This fixes Yoast/wordpress-seo#5632.

This depends on Yoast/wordpress-seo#7607 as it uses the exposed `ReplaceVar` class but will fail gracefully ( not do anything ) if it's not present.