### PR TITLE
Determine select2 version from ACF instead of guessing from ACF version

### DIFF
--- a/js/src/scraper/scraper.taxonomy.js
+++ b/js/src/scraper/scraper.taxonomy.js
@@ -17,7 +17,7 @@ Scraper.prototype.scrape = function(fields){
 
         if( field.$el.find('.acf-taxonomy-field[data-type="multi_select"]').length > 0 ){
 
-            var select2Target = (helper.acf_version >= 5.6)?'select':'input';
+            var select2Target = (acf.select2.version >= 4)?'select':'input';
 
             terms = _.pluck(
                 field.$el.find('.acf-taxonomy-field[data-type="multi_select"] ' + select2Target )

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -688,7 +688,7 @@ Scraper.prototype.scrape = function(fields){
 
         if( field.$el.find('.acf-taxonomy-field[data-type="multi_select"]').length > 0 ){
 
-            var select2Target = (helper.acf_version >= 5.6)?'select':'input';
+            var select2Target = (acf.select2.version >= 4)?'select':'input';
 
             terms = _.pluck(
                 field.$el.find('.acf-taxonomy-field[data-type="multi_select"] ' + select2Target )

--- a/tests/js/system/tests/acf5/relational.js
+++ b/tests/js/system/tests/acf5/relational.js
@@ -34,14 +34,14 @@ module.exports = {
 
         browser.execute(
             function() {
-                return parseFloat(YoastACFAnalysisConfig.acfVersion, 10);
+                return parseFloat(acf.select2.version, 10);
             },
             [],
             function( result ){
-                var acfVersion = result.value;
+                var select2Version = result.value;
                 var inputSelector, optionSelector, choiceSelector;
 
-                if( acfVersion >= 5.6 ){
+                if( select2Version >= 4 ){
                     inputSelector = '.acf-taxonomy-field[data-type="multi_select"][data-taxonomy="category"] .select2-search__field ';
                     optionSelector = '.select2-results__option--highlighted';
                     choiceSelector = '.acf-taxonomy-field .select2-selection__choice';
@@ -64,7 +64,7 @@ module.exports = {
                 browser.execute(
                     function() {
 
-                        var select2Target = (parseFloat(YoastACFAnalysisConfig.acfVersion, 10) >= 5.6)?'select':'input';
+                        var select2Target = (parseFloat(acf.select2.version, 10) >= 4)?'select':'input';
 
                         return jQuery('.acf-taxonomy-field[data-type="multi_select"] ' + select2Target).select2('data')[0].text
                     },


### PR DESCRIPTION
fixes #79 

This could probably still be improved as the case of ACF5 with select2 v3 is now not actually covered by the tests. But for that I am waiting for #103 because it will add the infrastructure to add a CPT for which we could then switch select2 to v3.