### PR TITLE
Convert launch URL to more general domain

### DIFF
--- a/tests/js/system/nightwatch.json
+++ b/tests/js/system/nightwatch.json
@@ -10,7 +10,7 @@
   },
   "test_settings": {
     "default" : {
-      "launch_url" : "http://yoast-acf-analysis.vvv.dev",
+      "launch_url" : "http://local.wordpress.dev",
       "globals" : {
       },
       "screenshots" : {


### PR DESCRIPTION
As this can be used without making use of the custom VVV testing environment, using a default VVV domain seems only logical.

The `nightwatch.config.example.js` now contains a replacement string, which will be filled with the actual domain when the VVV testing environmnet IS used. This will overwrite the domain configured here.