### PR TITLE
Remove testing code from plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,10 @@
   "autoload-dev": {
     "psr-4": {
       "Yoast\\AcfAnalysis\\Tests\\": "tests/php/unit"
-    }
+    },
+    "files": [
+      "tests/js/system/data/test-data-loader.php"
+    ]
   },
   "scripts": {
     "post-install-cmd": [

--- a/inc/class-ac-yoast-seo-acf-content-analysis.php
+++ b/inc/class-ac-yoast-seo-acf-content-analysis.php
@@ -28,10 +28,6 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 
 		$this->boot();
 
-		if ( defined( 'AC_YOAST_ACF_ANALYSIS_ENVIRONMENT' ) && 'development' === AC_YOAST_ACF_ANALYSIS_ENVIRONMENT ) {
-			$this->boot_dev();
-		}
-
 		$this->register_config_filters();
 
 		$assets = new Yoast_ACF_Analysis_Assets();
@@ -74,14 +70,6 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 		}
 
 		$registry->add( 'config', $configuration );
-	}
-
-	/**
-	 * Boots the plugin for dev environment.
-	 */
-	public function boot_dev() {
-		$version = ( -1 === version_compare( get_option( 'acf_version' ), 5 ) ) ? '4' : '5';
-		require_once AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/tests/js/system/data/acf' . $version . '.php';
 	}
 
 	/**

--- a/tests/js/system/data/test-data-loader.php
+++ b/tests/js/system/data/test-data-loader.php
@@ -1,11 +1,9 @@
 <?php
 
-// Load Monkey Brains WP mock methods if Plugin API is not available (e.g. in Unit Tests).
-if ( ! function_exists( 'add_action' ) ) {
-	Brain\Monkey\setUp();
+// Only load data when Plugin API is available because it is not needed in Unit Tests anyway.
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'admin_init', 'yoast_acf_analysis_test_data_loader', 11 );
 }
-
-add_action( 'admin_init', 'yoast_acf_analysis_test_data_loader', 11 );
 
 function yoast_acf_analysis_test_data_loader() {
 

--- a/tests/js/system/data/test-data-loader.php
+++ b/tests/js/system/data/test-data-loader.php
@@ -1,5 +1,10 @@
 <?php
 
+// Load Monkey Brains WP mock methods if Plugin API is not available (e.g. in Unit Tests).
+if ( ! function_exists( 'add_action' ) ) {
+	Brain\Monkey\setUp();
+}
+
 add_action( 'admin_init', 'yoast_acf_analysis_test_data_loader', 11 );
 
 function yoast_acf_analysis_test_data_loader() {

--- a/tests/js/system/data/test-data-loader.php
+++ b/tests/js/system/data/test-data-loader.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * This file is loaded by Composer autoload-dev, and that happens before `add_action` is available.
+ * So we "manually" add in global `$wp_filter` the function that loads translations.
+ */
+global $wp_filter;
+
+$hook_name = 'admin_init';
+$function_name = 'yoast_acf_analysis_test_data_loader';
+
+if ( ! is_array( $wp_filter ) ) {
+	$wp_filter = array();
+}
+
+if ( ! isset( $wp_filter[ $hook_name ] ) ) {
+	$wp_filter[ $hook_name ] = array();
+}
+
+if ( ! isset( $wp_filter[ $hook_name ][10] ) ) {
+	$wp_filter[ $hook_name ][10] = array();
+}
+
+$wp_filter[ $hook_name ][10][ $function_name ] = array(
+	'function' => $function_name,
+	'accepted_args' => 1,
+);
+
+function yoast_acf_analysis_test_data_loader() {
+
+	if ( defined( 'AC_YOAST_ACF_ANALYSIS_ENVIRONMENT' ) && 'development' === AC_YOAST_ACF_ANALYSIS_ENVIRONMENT ) {
+
+		$version = ( -1 === version_compare( get_option( 'acf_version' ), 5 ) ) ? '4' : '5';
+		require_once AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/tests/js/system/data/acf' . $version . '.php';
+
+	}
+
+}

--- a/tests/js/system/data/test-data-loader.php
+++ b/tests/js/system/data/test-data-loader.php
@@ -28,7 +28,7 @@ if ( ! function_exists( 'add_action' ) ) {
 		'accepted_args' => 1,
 	);
 
-}else{
+} else {
 
 	add_action( $hook_name, $function_name, 11 );
 

--- a/tests/js/system/data/test-data-loader.php
+++ b/tests/js/system/data/test-data-loader.php
@@ -1,38 +1,6 @@
 <?php
 
-/**
- * This file is loaded by Composer autoload-dev, and that happens before `add_action` is available.
- * So we "manually" add in global `$wp_filter` the function that loads translations.
- */
-global $wp_filter;
-
-$hook_name = 'admin_init';
-$function_name = 'yoast_acf_analysis_test_data_loader';
-
-if ( ! function_exists( 'add_action' ) ) {
-
-	if ( ! is_array( $wp_filter ) ) {
-		$wp_filter = array();
-	}
-
-	if ( ! isset( $wp_filter[ $hook_name ] ) ) {
-		$wp_filter[ $hook_name ] = array();
-	}
-
-	if ( ! isset( $wp_filter[ $hook_name ][11] ) ) {
-		$wp_filter[ $hook_name ][11] = array();
-	}
-
-	$wp_filter[ $hook_name ][11][ $function_name ] = array(
-		'function' => $function_name,
-		'accepted_args' => 1,
-	);
-
-} else {
-
-	add_action( $hook_name, $function_name, 11 );
-
-}
+add_action( 'admin_init', 'yoast_acf_analysis_test_data_loader', 11 );
 
 function yoast_acf_analysis_test_data_loader() {
 

--- a/tests/js/system/data/test-data-loader.php
+++ b/tests/js/system/data/test-data-loader.php
@@ -36,18 +36,18 @@ if ( ! function_exists( 'add_action' ) ) {
 
 function yoast_acf_analysis_test_data_loader() {
 
-	if ( defined( 'AC_YOAST_ACF_ANALYSIS_ENVIRONMENT' ) && 'development' === AC_YOAST_ACF_ANALYSIS_ENVIRONMENT ) {
-
-		$registry = Yoast_ACF_Analysis_Facade::get_registry();
-		$configuration = $registry->get( 'config' );
-
-		$version = 4;
-		if ( version_compare( $configuration->get_acf_version(), 5, '>=' ) ) {
-			$version = 5;
-		}
-
-		require_once AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/tests/js/system/data/acf' . $version . '.php';
-
+	if ( ! defined( 'AC_YOAST_ACF_ANALYSIS_ENVIRONMENT' ) || 'development' !== AC_YOAST_ACF_ANALYSIS_ENVIRONMENT ) {
+		return;
 	}
+
+	$registry = Yoast_ACF_Analysis_Facade::get_registry();
+	$configuration = $registry->get( 'config' );
+
+	$version = 4;
+	if ( version_compare( $configuration->get_acf_version(), 5, '>=' ) ) {
+		$version = 5;
+	}
+
+	require_once AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/tests/js/system/data/acf' . $version . '.php';
 
 }

--- a/tests/js/system/data/test-data-loader.php
+++ b/tests/js/system/data/test-data-loader.php
@@ -19,18 +19,18 @@ if ( ! function_exists( 'add_action' ) ) {
 		$wp_filter[ $hook_name ] = array();
 	}
 
-	if ( ! isset( $wp_filter[ $hook_name ][10] ) ) {
-		$wp_filter[ $hook_name ][10] = array();
+	if ( ! isset( $wp_filter[ $hook_name ][11] ) ) {
+		$wp_filter[ $hook_name ][11] = array();
 	}
 
-	$wp_filter[ $hook_name ][10][ $function_name ] = array(
+	$wp_filter[ $hook_name ][11][ $function_name ] = array(
 		'function' => $function_name,
 		'accepted_args' => 1,
 	);
 
 }else{
 
-	add_action( $hook_name, $function_name );
+	add_action( $hook_name, $function_name, 11 );
 
 }
 
@@ -38,7 +38,14 @@ function yoast_acf_analysis_test_data_loader() {
 
 	if ( defined( 'AC_YOAST_ACF_ANALYSIS_ENVIRONMENT' ) && 'development' === AC_YOAST_ACF_ANALYSIS_ENVIRONMENT ) {
 
-		$version = ( -1 === version_compare( get_option( 'acf_version' ), 5 ) ) ? '4' : '5';
+		$registry = Yoast_ACF_Analysis_Facade::get_registry();
+		$configuration = $registry->get( 'config' );
+
+		$version = 4;
+		if ( version_compare( $configuration->get_acf_version(), 5, '>=' ) ) {
+			$version = 5;
+		}
+
 		require_once AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/tests/js/system/data/acf' . $version . '.php';
 
 	}

--- a/tests/js/system/data/test-data-loader.php
+++ b/tests/js/system/data/test-data-loader.php
@@ -9,22 +9,30 @@ global $wp_filter;
 $hook_name = 'admin_init';
 $function_name = 'yoast_acf_analysis_test_data_loader';
 
-if ( ! is_array( $wp_filter ) ) {
-	$wp_filter = array();
-}
+if ( ! function_exists( 'add_action' ) ) {
 
-if ( ! isset( $wp_filter[ $hook_name ] ) ) {
-	$wp_filter[ $hook_name ] = array();
-}
+	if ( ! is_array( $wp_filter ) ) {
+		$wp_filter = array();
+	}
 
-if ( ! isset( $wp_filter[ $hook_name ][10] ) ) {
-	$wp_filter[ $hook_name ][10] = array();
-}
+	if ( ! isset( $wp_filter[ $hook_name ] ) ) {
+		$wp_filter[ $hook_name ] = array();
+	}
 
-$wp_filter[ $hook_name ][10][ $function_name ] = array(
-	'function' => $function_name,
-	'accepted_args' => 1,
-);
+	if ( ! isset( $wp_filter[ $hook_name ][10] ) ) {
+		$wp_filter[ $hook_name ][10] = array();
+	}
+
+	$wp_filter[ $hook_name ][10][ $function_name ] = array(
+		'function' => $function_name,
+		'accepted_args' => 1,
+	);
+
+}else{
+
+	add_action( $hook_name, $function_name );
+
+}
 
 function yoast_acf_analysis_test_data_loader() {
 

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -27,14 +27,14 @@ if ( ! defined( 'AC_SEO_ACF_ANALYSIS_PLUGIN_PATH' ) ) {
 	define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_NAME', untrailingslashit( plugin_basename( __FILE__ ) ) );
 }
 
-if ( version_compare( PHP_VERSION, '5.3.2', '>=' ) ) {
-	if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload.php' ) ) {
-		require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload.php';
-	}
-} else {
-	if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload_52.php' ) ) {
-		require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload_52.php';
-	}
+$autoload_file = '/vendor/autoload.php';
+
+if ( version_compare( PHP_VERSION, '5.3.2', '<' ) ) {
+	$autoload_file = '/vendor/autoload_52.php';
+}
+
+if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . $autoload_file ) ) {
+	require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . $autoload_file;
 }
 
 /**

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -27,11 +27,14 @@ if ( ! defined( 'AC_SEO_ACF_ANALYSIS_PLUGIN_PATH' ) ) {
 	define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_NAME', untrailingslashit( plugin_basename( __FILE__ ) ) );
 }
 
-if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload_52.php' ) ) {
-	require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload_52.php';
-
-	$ac_yoast_seo_acf_analysis = new AC_Yoast_SEO_ACF_Content_Analysis();
-	$ac_yoast_seo_acf_analysis->init();
+if ( version_compare( PHP_VERSION, '5.3.2', '>=' ) ) {
+	if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload.php' ) ) {
+		require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload.php';
+	}
+} else {
+	if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload_52.php' ) ) {
+		require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/vendor/autoload_52.php';
+	}
 }
 
 /**
@@ -57,4 +60,7 @@ if ( ! class_exists( 'AC_Yoast_SEO_ACF_Content_Analysis' ) && is_admin() ) {
 		'admin_notices',
 		create_function( '', "echo '<div class=\"error\"><p>$message</p></div>';" )
 	);
+} else {
+	$ac_yoast_seo_acf_analysis = new AC_Yoast_SEO_ACF_Content_Analysis();
+	$ac_yoast_seo_acf_analysis->init();
 }


### PR DESCRIPTION
## Summary

As noticed in #103 it is not ideal to handle the loading of testing data inside the production plugin code as said in #111.

I've been thinking about several approaches: This PR proposes the one I like the most.

## Relevant technical choices:

* No code left in Plugin itself
* Load dev bootstrap with composers [autoload/files functionality](https://getcomposer.org/doc/04-schema.md#files)
* Use normal composer autoloader with PHP 5.3.2+ as [`xrstf/composer-php52`](https://github.com/composer-php52/composer-php52) apparently doesn't support the `files` autoload functionality, hence this only works with PHP 5.3.2+. But as this is only needed for client-side tests those shouldn't really care about the PHP version in use.
* Adds hooks before WP is initialized by adding a hook to  `global $wp_filter`

## Test instructions

This PR can be tested by following these steps:

* Checkout the branch and make sure to `composer dumpautoload` afterwards so the autoloader is regenerated.

Possibly fixes #111 
