### PR TITLE
README: fix header tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 4.8.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Stable tag: 2.0.1
-Text Domain: acf-content-analysis-for-yoast-seo
+Requires PHP: 5.2.4
 
 WordPress plugin that adds the content of all ACF fields to the Yoast SEO score analysis.
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

* The `text-domain` tag should be at the top of the plugin file, not the readme (where it already is).
* Adds the new `Requires PHP` tag.
