### PR TITLE
Travis: various tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,3 +74,4 @@ script:
 - if [[ "$PHPCS" == "1" ]]; then composer configure-phpcs; composer check-cs-errors; fi
 - if [[ "$CHECKJS" == "1" ]]; then grunt check; fi
 - if [[ "$PHPUNIT" == "1" ]]; then composer test; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,15 @@ language: php
 dist: trusty
 sudo: false
 
+cache:
+  yarn: true
+  directories:
+    - vendor
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
+
 branches:
   only:
     - master
@@ -18,12 +27,6 @@ jobs:
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
       env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1
-
-cache:
-  yarn: true
-  directories:
-    - vendor
-    - $HOME/.composer/cache
 
 before_install:
 - if [[ "$CHECKJS" == "1" ]]; then nvm install $TRAVIS_NODE_VERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,26 @@ branches:
     - /^release\/\d+\.\d+(\.\d+)?(-\S*)?$/
     - /^hotfix\/\d+\.\d+(\.\d+)?(-\S*)?$/
 
-jobs:
+matrix:
   fast_finish: true
   include:
-    - php: 7.1
-      env: WP_VERSION=4.8 WP_MULTISITE=1 PHPLINT=1 PHPCS=1 CHECKJS=1 PHPUNIT=1 TRAVIS_NODE_VERSION=node
+    - php: 7.2
+      env: WP_VERSION=4.9 WP_MULTISITE=1 PHPCS=1 CHECKJS=1 PHPUNIT=1 TRAVIS_NODE_VERSION=node
     - php: 5.2
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
-      env: WP_VERSION=4.7 WP_MULTISITE=1 PHPLINT=1
+    - php: 5.3
+      dist: precise
+    - php: 5.6
+      env: PHPUNIT=1 WP_VERSION=4.7
+    - php: 7.0
+      env: PHPUNIT=1 WP_VERSION=4.8
+    - php: nightly
+      env: PHPUNIT=1 WP_VERSION=master
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: nightly
+    - env: WP_VERSION=master
 
 before_install:
 - if [[ "$CHECKJS" == "1" ]]; then nvm install $TRAVIS_NODE_VERSION; fi
@@ -34,29 +45,32 @@ before_install:
 - if [[ "$CHECKJS" == "1" ]]; then export PATH=$HOME/.yarn/bin:$PATH; fi
 
 install:
-- if [[ ${TRAVIS_PHP_VERSION:0:1} == "7" && ${TRAVIS_PHP_VERSION:0:3} != "7.0" || $TRAVIS_PHP_VERSION == "nightly" ]]; then composer install --no-interaction; fi
+- if [[ "$PHPUNIT" == "1" ]]; then composer install --no-interaction; fi
 - if [[ "$CHECKJS" == "1" ]]; then yarn global add grunt-cli; fi
 - if [[ "$CHECKJS" == "1" ]]; then yarn install; fi
 
 before_script:
-- PLUGIN_SLUG=$(basename $(pwd))
-- export WP_DEVELOP_DIR=/tmp/wordpress/
-- git clone --depth=50 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
-- cd ..
-- cp -r "$PLUGIN_SLUG" "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-- cd /tmp/wordpress/
-- cp wp-tests-config-sample.php wp-tests-config.php
-- sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-- sed -i "s/yourusernamehere/travis/" wp-tests-config.php
-- sed -i "s/yourpasswordhere//" wp-tests-config.php
-- mysql -e "CREATE DATABASE wordpress_tests;" -uroot
-- cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-- phpenv rehash
+- |
+  if [[ "$PHPUNIT" == "1" ]]; then
+    PLUGIN_SLUG=$(basename $(pwd))
+    export WP_DEVELOP_DIR=/tmp/wordpress/
+    git clone --depth=50 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
+    cd ..
+    cp -r "$PLUGIN_SLUG" "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
+    cd /tmp/wordpress/
+    cp wp-tests-config-sample.php wp-tests-config.php
+    sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
+    sed -i "s/yourusernamehere/travis/" wp-tests-config.php
+    sed -i "s/yourpasswordhere//" wp-tests-config.php
+    mysql -e "CREATE DATABASE wordpress_tests;" -uroot
+    cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
+    phpenv rehash
+  fi
 
 script:
-# Exclude tests directory from linting for PHP 5.x
-- if [[ "$PHPLINT" == "1" && ${TRAVIS_PHP_VERSION:0:1} == "5" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -path ./tests -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
-- if [[ "$PHPLINT" == "1" && ${TRAVIS_PHP_VERSION:0:1} == "7" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
+# Exclude tests directory from linting for PHP 5.2/3
+- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -path ./tests -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
+- if [[ $TRAVIS_PHP_VERSION != "5.2" && $TRAVIS_PHP_VERSION != "5.3" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
 - if [[ "$PHPCS" == "1" ]]; then composer configure-phpcs; composer check-cs-errors; fi
 - if [[ "$CHECKJS" == "1" ]]; then grunt check; fi
 - if [[ "$PHPUNIT" == "1" ]]; then composer test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,8 @@ before_script:
 
 script:
 # Exclude tests directory from linting for PHP 5.2/3
-- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -path ./tests -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
-- if [[ $TRAVIS_PHP_VERSION != "5.2" && $TRAVIS_PHP_VERSION != "5.3" ]]; then find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then if  find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -path ./tests -prune -o -name '*.php' -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+- if [[ $TRAVIS_PHP_VERSION != "5.2" && $TRAVIS_PHP_VERSION != "5.3" ]]; then if find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
 - if [[ "$PHPCS" == "1" ]]; then composer configure-phpcs; composer check-cs-errors; fi
 - if [[ "$CHECKJS" == "1" ]]; then grunt check; fi
 - if [[ "$PHPUNIT" == "1" ]]; then composer test; fi


### PR DESCRIPTION
### Build/Travis: cache the correct Composer directories

As a side-note: my research into this actual suggests not to add the `vendor` directory to the `cache` list. I've not removed it, but just thought I'd mention it.

### Build/Travis: use a more complete PHP matrix

Linting should be done against all PHP versions or at least against the lowest and highest of each major, so:
* Add more PHP versions.
* Up the main build to use PHP `7.2` instead of `7.1`.
* No need for an environment variable to enable linting.
* Remove comments about PHP 5.2/5.3 vs `precise`, this can by now be considered a known issue.
* As the unit tests for Yoast ACF require PHP 5.6+, there is no need to pull WP in for earlier PHP versions, nor to run the unit tests on earlier PHP versions. Using the `PHPUNIT` environment variable to toggle this (and the `composer install` command).

### Build/Travis: update the linting command

Changed the linting command to give one-liner output.

### Build/Travis: validate the composer.json file

Validate the composer.json file on highest/lowest Composer compatible PHP build.
Ref: https://getcomposer.org/doc/03-cli.md#validate

:point_right: As a side-note this raises two questions:
1. Is the license `GPL-3.0` or `GPL-3.0-or-later` ? Currently - in contrast to most repos -, this repo uses `GPL-3.0`.
2. The repo contains two license files. `LICENSE` and `license.txt`. It seems prudent to only include one. Which one should be removed ?


~~**N.B.**: The Travis failure has to do with the upping of the PHP version on which PHPCS is run from `7.1` to `7.2` as it now starts reporting on the deprecated `create_function()` usage.
That is already addressed in a separate PR #135, so I will rebase this PR after #135 has been merged and it should then pass without issue.
Sorry, clearly I didn't calculate in the conflicts well enough for this repo.~~