### PR TITLE
CS/QA: rename a global variable

### DIFF
--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -27,14 +27,14 @@ if ( ! defined( 'AC_SEO_ACF_ANALYSIS_PLUGIN_PATH' ) ) {
 	define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_NAME', untrailingslashit( plugin_basename( __FILE__ ) ) );
 }
 
-$autoload_file = '/vendor/autoload.php';
+$yoast_acf_autoload_file = '/vendor/autoload.php';
 
 if ( version_compare( PHP_VERSION, '5.3.2', '<' ) ) {
-	$autoload_file = '/vendor/autoload_52.php';
+	$yoast_acf_autoload_file = '/vendor/autoload_52.php';
 }
 
-if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . $autoload_file ) ) {
-	require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . $autoload_file;
+if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . $yoast_acf_autoload_file ) ) {
+	require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . $yoast_acf_autoload_file;
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Prevent conflicts with other plugins/themes.

## Relevant technical choices:

This variable is defined in the global namespace with a dangerously generic name.
Changing the variables name can be regarded as a backward-compatibility break, albeit very minor, however, leaving the name as it is can be considered a bug.


## Test instructions

This PR can be tested by following these steps:
* The plugin should still load as expected.

