### PR TITLE
QA: refactor code to remove usage of `create_function()`

### DIFF
--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -49,19 +49,23 @@ function yoast_acf_analysis_load_textdomain() {
 /**
  * Triggers a message whenever the class is missing.
  */
-if ( ! class_exists( 'AC_Yoast_SEO_ACF_Content_Analysis' ) && is_admin() ) {
-	$message = sprintf(
-		/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO */
-		__( '%1$s could not be loaded because of missing files.', 'acf-content-analysis-for-yoast-seo' ),
-		'ACF Content Analysis for Yoast SEO'
-	);
-
-	add_action(
-		'admin_notices',
-		create_function( '', "echo '<div class=\"error\"><p>$message</p></div>';" )
-	);
+if ( ! class_exists( 'AC_Yoast_SEO_ACF_Content_Analysis' ) ) {
+	add_action( 'admin_notices', 'yoast_acf_report_missing_acf' );
 }
 else {
 	$ac_yoast_seo_acf_analysis = new AC_Yoast_SEO_ACF_Content_Analysis();
 	$ac_yoast_seo_acf_analysis->init();
+}
+
+/**
+ * Show admin notice when ACF is missing.
+ */
+function yoast_acf_report_missing_acf() {
+	echo '<div class="error"><p>';
+	printf(
+		/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO */
+		esc_html__( '%1$s could not be loaded because of missing files.', 'acf-content-analysis-for-yoast-seo' ),
+		'ACF Content Analysis for Yoast SEO'
+	);
+	echo '</p></div>';
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
* Improved compatibility with PHP 7.2+.
* Security hardening.
* Prevent conflicts with other plugins/themes.
* Prevent a potential fatal error.

## Relevant technical choices:

This minor refactor actually solves four problems:
* PHP 7.2+ compatibility - `create_function()` has been deprecated and will be removed in PHP 8.0.
* The variable `$message` was a global variable which, considering its generic variable name, could lead to unexpected results if/when other plugins/themes would also use that variable.
* `$message` was not being escaped for output which - if the variable would have been hijacked by another plugin/theme could have led to a hacked admin interface.
* The original conditional `! class_exists( 'AC_Yoast_SEO_ACF_Content_Analysis' ) && is_admin()` was incorrect and could lead to the situation where the script would still try to load the `AC_Yoast_SEO_ACF_Content_Analysis` class via the `else` even when its not available, potentially leading to fatal errors on the web front-end.
    I've now removed the `is_admin()` check as the `admin_notices` hook only runs when in the back-end, so we don't need to check for this ourselves.

**N.B.:** The build for this will pass once I've rebased this PR after the whitespace PR has been merged.

## Test instructions

This PR can be tested by following these steps:
* Check that the plugin still loads as expected when ACF is active.
* Verify that the admin notice displays correctly when ACF is not active.

