### PR TITLE
CS: fix unnecessary usage of double quotes

### DIFF
--- a/tests/php/unit/Configuration/StringStoreTest.php
+++ b/tests/php/unit/Configuration/StringStoreTest.php
@@ -19,7 +19,7 @@ class StringStoreTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAdd() {
 
-		$type = "test";
+		$type = 'test';
 
 		$store = $this->getStore();
 		$store->add( $type );
@@ -30,7 +30,7 @@ class StringStoreTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAddSame() {
 
-		$type = "test";
+		$type = 'test';
 
 		$store = $this->getStore();
 		$store->add( $type );
@@ -42,8 +42,8 @@ class StringStoreTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAddMultiple() {
 
-		$typeA = "A";
-		$typeB = "B";
+		$typeA = 'A';
+		$typeB = 'B';
 
 		$store = $this->getStore();
 		$store->add( $typeA );
@@ -55,8 +55,8 @@ class StringStoreTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAddMultipleSorting() {
 
-		$typeA = "Z";
-		$typeB = "A";
+		$typeA = 'Z';
+		$typeB = 'A';
 
 		$store = $this->getStore();
 		$store->add( $typeA );
@@ -77,8 +77,8 @@ class StringStoreTest extends \PHPUnit_Framework_TestCase {
 
 	public function testRemove() {
 
-		$typeA = "A";
-		$typeB = "B";
+		$typeA = 'A';
+		$typeB = 'B';
 
 		$store = $this->getStore();
 
@@ -100,7 +100,7 @@ class StringStoreTest extends \PHPUnit_Framework_TestCase {
 	public function testRemoveNonString() {
 
 		$store = $this->getStore();
-		$store->add( "999" );
+		$store->add( '999' );
 
 		$this->assertFalse( $store->remove( 999 ) );
 
@@ -110,7 +110,7 @@ class StringStoreTest extends \PHPUnit_Framework_TestCase {
 
 		$store = $this->getStore();
 
-		$this->assertFalse( $store->remove( "test" ) );
+		$this->assertFalse( $store->remove( 'test' ) );
 
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:
_N/A_

## Relevant technical choices:
* No functional changes.
* Code style compliance. Compliance with the `Squiz.Strings.DoubleQuoteUsage` sniff.

Using double quotes is marginally slower than single quotes as PHP will try and find interpolated variables in the string. Whenever reasonable, using single quotes is preferred.

Valid use cases for double quoted strings:
* When there is an interpolated variable
* When the string contains single quotes

## Test instructions

_N/A_