### PR TITLE
Tests: safeguard setup teardown method consistency

### DIFF
--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -13,6 +13,11 @@ class Configuration_Test extends \PHPUnit_Framework_TestCase {
 		Monkey\setUp();
 	}
 
+	protected function tearDown() {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
 	public function testEmpty() {
 
 		$configuration = new \Yoast_ACF_Analysis_Configuration(
@@ -288,10 +293,5 @@ class Configuration_Test extends \PHPUnit_Framework_TestCase {
 
 		$this->assertSame( $store, $configuration->get_field_selectors() );
 
-	}
-
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 }

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -8,11 +8,17 @@ use Brain\Monkey\Functions;
 
 class Configuration_Test extends \PHPUnit_Framework_TestCase {
 
+	/**
+	 * Set up test fixtures.
+	 */
 	protected function setUp() {
 		parent::setUp();
 		Monkey\setUp();
 	}
 
+	/**
+	 * Tear down test fixtures previously setup.
+	 */
 	protected function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -5,11 +5,17 @@ namespace Yoast\AcfAnalysis\Tests\Dependencies;
 use Brain\Monkey;
 
 class ACF_Dependency_Test extends \PHPUnit_Framework_TestCase {
+	/**
+	 * Set up test fixtures.
+	 */
 	protected function setUp() {
 		parent::setUp();
 		Monkey\setUp();
 	}
 
+	/**
+	 * Tear down test fixtures previously setup.
+	 */
 	protected function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -10,6 +10,11 @@ class ACF_Dependency_Test extends \PHPUnit_Framework_TestCase {
 		Monkey\setUp();
 	}
 
+	protected function tearDown() {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
 	public function testNoACFClassExists() {
 		$testee = new \Yoast_ACF_Analysis_Dependency_ACF();
 
@@ -29,10 +34,5 @@ class ACF_Dependency_Test extends \PHPUnit_Framework_TestCase {
 		$testee->register_notifications();
 
 		$this->assertTrue( has_action( 'admin_notices', array( $testee, 'message_plugin_not_activated' ) ) );
-	}
-
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 }

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -8,11 +8,17 @@ class Yoast_SEO_Dependency_Test extends \PHPUnit_Framework_TestCase {
 	protected $preserveGlobalState      = false;
 	protected $runTestInSeparateProcess = true;
 
+	/**
+	 * Set up test fixtures.
+	 */
 	protected function setUp() {
 		parent::setUp();
 		Monkey\setUp();
 	}
 
+	/**
+	 * Tear down test fixtures previously setup.
+	 */
 	protected function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -13,6 +13,11 @@ class Yoast_SEO_Dependency_Test extends \PHPUnit_Framework_TestCase {
 		Monkey\setUp();
 	}
 
+	protected function tearDown() {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
 	public function testFail() {
 		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 
@@ -47,10 +52,5 @@ class Yoast_SEO_Dependency_Test extends \PHPUnit_Framework_TestCase {
 		$testee->register_notifications();
 
 		$this->assertTrue( has_action( 'admin_notices', array( $testee, 'message_minimum_version' ) ) );
-	}
-
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 }

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -9,11 +9,17 @@ class Assets_Test extends \PHPUnit_Framework_TestCase {
 	protected $preserveGlobalState      = false;
 	protected $runTestInSeparateProcess = true;
 
+	/**
+	 * Set up test fixtures.
+	 */
 	protected function setUp() {
 		parent::setUp();
 		Monkey\setUp();
 	}
 
+	/**
+	 * Tear down test fixtures previously setup.
+	 */
 	protected function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -14,6 +14,11 @@ class Assets_Test extends \PHPUnit_Framework_TestCase {
 		Monkey\setUp();
 	}
 
+	protected function tearDown() {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
 	public function testInitHook() {
 		define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_FILE', '/directory/file' );
 		Functions\expect( 'get_plugin_data' )
@@ -29,10 +34,5 @@ class Assets_Test extends \PHPUnit_Framework_TestCase {
 		$testee->init();
 
 		$this->assertTrue( has_filter( 'admin_enqueue_scripts', array( $testee, 'enqueue_scripts' ) ) );
-	}
-
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 }

--- a/tests/php/unit/main-test.php
+++ b/tests/php/unit/main-test.php
@@ -6,11 +6,17 @@ use Brain\Monkey;
 
 class Main_Test extends \PHPUnit_Framework_TestCase {
 
+	/**
+	 * Set up test fixtures.
+	 */
 	protected function setUp() {
 		parent::setUp();
 		Monkey\setUp();
 	}
 
+	/**
+	 * Tear down test fixtures previously setup.
+	 */
 	protected function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/tests/php/unit/main-test.php
+++ b/tests/php/unit/main-test.php
@@ -11,6 +11,11 @@ class Main_Test extends \PHPUnit_Framework_TestCase {
 		Monkey\setUp();
 	}
 
+	protected function tearDown() {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
 	public function testInvalidConfig() {
 		$registry = \Yoast_ACF_Analysis_Facade::get_registry();
 
@@ -22,10 +27,5 @@ class Main_Test extends \PHPUnit_Framework_TestCase {
 		$this->assertNotSame( 'Invalid Config', $registry->get( 'config' ) );
 		$this->assertInstanceOf( \Yoast_ACF_Analysis_Configuration::class, $registry->get( 'config' ) );
 
-	}
-
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 }

--- a/tests/php/unit/requirements-test.php
+++ b/tests/php/unit/requirements-test.php
@@ -48,6 +48,9 @@ class Failing_Dependency implements \Yoast_ACF_Analysis_Dependency {
 
 class Requirements_Test extends \PHPUnit_Framework_TestCase {
 
+	/**
+	 * Set up test fixtures.
+	 */
 	protected function setUp() {
 		parent::setUp();
 		Monkey\setUp();
@@ -55,6 +58,9 @@ class Requirements_Test extends \PHPUnit_Framework_TestCase {
 		Functions\expect( 'current_user_can' )->andReturn( true );
 	}
 
+	/**
+	 * Tear down test fixtures previously setup.
+	 */
 	protected function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();

--- a/tests/php/unit/requirements-test.php
+++ b/tests/php/unit/requirements-test.php
@@ -55,6 +55,11 @@ class Requirements_Test extends \PHPUnit_Framework_TestCase {
 		Functions\expect( 'current_user_can' )->andReturn( true );
 	}
 
+	protected function tearDown() {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
 	public function testNoDependencies() {
 		$testee = new \Yoast_ACF_Analysis_Requirements();
 		$this->assertTrue( $testee->are_met() );
@@ -81,10 +86,4 @@ class Requirements_Test extends \PHPUnit_Framework_TestCase {
 
 		$this->assertFalse( $testee->are_met() );
 	}
-
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
-	}
-
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Tests: always keep the `setUp()` and `tearDown()` methods together
    ... to make it easy for other devs to verify that any fixtures which are setup are also torn down.
* Documentation: add perfunctory documentation to test `setUp()`/`tearDown()` methods


## Test instructions

This PR can be tested by following these steps:

* _N/A_
