### PR TITLE
Best practices: only one class per file

### DIFF
--- a/tests/php/unit/Doubles/failing-dependency.php
+++ b/tests/php/unit/Doubles/failing-dependency.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\AcfAnalysis\Tests\Doubles;
+
+class Failing_Dependency implements \Yoast_ACF_Analysis_Dependency {
+	/**
+	 * Checks if this dependency is met.
+	 *
+	 * @return bool True when met, False when not met.
+	 */
+	public function is_met() {
+		return false;
+	}
+
+	/**
+	 * Registers the notifications to communicate the depedency is not met.
+	 *
+	 * @return void
+	 */
+	public function register_notifications() {
+	}
+}

--- a/tests/php/unit/Doubles/passing-dependency.php
+++ b/tests/php/unit/Doubles/passing-dependency.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Yoast\AcfAnalysis\Tests\Doubles;
+
+class Passing_Dependency implements \Yoast_ACF_Analysis_Dependency {
+	/**
+	 * Checks if this dependency is met.
+	 *
+	 * @return bool True when met, False when not met.
+	 */
+	public function is_met() {
+		return true;
+	}
+
+	/**
+	 * Registers the notifications to communicate the depedency is not met.
+	 *
+	 * @return void
+	 */
+	public function register_notifications() {
+	}
+}

--- a/tests/php/unit/requirements-test.php
+++ b/tests/php/unit/requirements-test.php
@@ -6,45 +6,8 @@ namespace Yoast\AcfAnalysis\Tests\Configuration;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use Brain\Monkey\Filters;
-
-
-class Passing_Dependency implements \Yoast_ACF_Analysis_Dependency {
-	/**
-	 * Checks if this dependency is met.
-	 *
-	 * @return bool True when met, False when not met.
-	 */
-	public function is_met() {
-		return true;
-	}
-
-	/**
-	 * Registers the notifications to communicate the depedency is not met.
-	 *
-	 * @return void
-	 */
-	public function register_notifications() {
-	}
-}
-
-class Failing_Dependency implements \Yoast_ACF_Analysis_Dependency {
-	/**
-	 * Checks if this dependency is met.
-	 *
-	 * @return bool True when met, False when not met.
-	 */
-	public function is_met() {
-		return false;
-	}
-
-	/**
-	 * Registers the notifications to communicate the depedency is not met.
-	 *
-	 * @return void
-	 */
-	public function register_notifications() {
-	}
-}
+use Yoast\AcfAnalysis\Tests\Doubles\Passing_Dependency;
+use Yoast\AcfAnalysis\Tests\Doubles\Failing_Dependency;
 
 class Requirements_Test extends \PHPUnit_Framework_TestCase {
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Put the helper classes for the `Requirements_Test` each in a separate file in a new `Doubles` directory.


## Test instructions

This PR can be tested by following these steps:

* Verify that the unit tests are still run & pass.