### PR TITLE
Introduce new filter to adjust field order

### DIFF
--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -245,6 +245,35 @@ class Yoast_ACF_Analysis_Configuration {
 	}
 
 	/**
+	 * Retrieves the field order.
+	 *
+	 * @return array The field order configuration
+	 */
+	public function get_field_order() {
+		/**
+		 * Filters the order of the ACF fields relative to the .
+		 *
+		 * The array has the ACF field key as the array key and the value should be an integer
+		 * where negative values result in the field value being placed before the default post_content
+		 *
+		 * So this is how to make the field with the key "field_591eb45f2be86" being placed before
+		 * the post_content:
+		 *
+		 *     $order_config = array(
+		 *          'field_591eb45f2be86' => -1
+		 *     );
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param array $order_config {
+		 *      @type string $field_name     Name of the ACF field
+		 *      @type int    $order          Integer
+		 * }
+		 */
+		return apply_filters( Yoast_ACF_Analysis_Facade::get_filter_name( 'field_order' ), array() );
+	}
+
+	/**
 	 * Retrieves an array representation of the current object.
 	 *
 	 * @return array
@@ -258,6 +287,7 @@ class Yoast_ACF_Analysis_Configuration {
 			'blacklistType'  => $this->get_blacklist_type()->to_array(),
 			'blacklistName'  => $this->get_blacklist_name()->to_array(),
 			'fieldSelectors' => $this->get_field_selectors()->to_array(),
+			'fieldOrder'     => $this->get_field_order(),
 			'debug'          => $this->is_debug(),
 		);
 	}

--- a/js/src/collect/collect.js
+++ b/js/src/collect/collect.js
@@ -9,7 +9,7 @@ var Collect = function() {
 };
 
 Collect.prototype.getFieldData = function() {
-	var field_data = this.filterBroken( this.filterBlacklistName( this.filterBlacklistType( this.getData() ) ) );
+	var field_data = this.sort( this.filterBroken( this.filterBlacklistName( this.filterBlacklistType( this.getData() ) ) ) );
 
 	var used_types = _.uniq( _.pluck( field_data, "type" ) );
 
@@ -34,6 +34,10 @@ Collect.prototype.append = function( data ) {
 
 	_.each( field_data, function( field ) {
 		if ( typeof field.content !== "undefined" && field.content !== "" ) {
+			if ( field.order < 0 ) {
+				data = field.content + "\n" + data;
+				return;
+			}
 			data += "\n" + field.content;
 		}
 	} );
@@ -72,6 +76,16 @@ Collect.prototype.filterBroken = function( field_data ) {
 	return _.filter( field_data, function( field ) {
 		return ( "key" in field );
 	} );
+};
+
+Collect.prototype.sort = function( field_data ) {
+	if ( typeof config.fieldOrder === "undefined" || !config.fieldOrder ) {
+		return field_data;
+	}
+	_.each( field_data, function( field ) {
+		field.order = ( typeof config.fieldOrder[ field.name ] !== "undefined" ) ? config.fieldOrder[ field.name ] : 0;
+	} );
+	return field_data.sort( function ( a, b ) { return a.order > b.order; } );
 };
 
 module.exports = new Collect();

--- a/js/src/scraper/scraper.text.js
+++ b/js/src/scraper/scraper.text.js
@@ -25,6 +25,8 @@ Scraper.prototype.wrapInHeadline = function( field ) {
 	var level = this.isHeadline( field );
 	if ( level ) {
 		field.content = "<h" + level + ">" + field.content + "</h" + level + ">";
+	} else {
+		field.content = "<p>" + field.content + "</p>";
 	}
 
 	return field;

--- a/js/src/scraper/scraper.textarea.js
+++ b/js/src/scraper/scraper.textarea.js
@@ -8,7 +8,7 @@ Scraper.prototype.scrape = function( fields ) {
 			return field;
 		}
 
-		field.content = field.$el.find( "textarea[id^=acf]" ).val();
+		field.content = "<p>" + field.$el.find( "textarea[id^=acf]" ).val() + "</p>";
 
 		return field;
 	} );

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -282,7 +282,7 @@ var Collect = function() {
 };
 
 Collect.prototype.getFieldData = function() {
-	var field_data = this.filterBroken( this.filterBlacklistName( this.filterBlacklistType( this.getData() ) ) );
+	var field_data = this.sort( this.filterBroken( this.filterBlacklistName( this.filterBlacklistType( this.getData() ) ) ) );
 
 	var used_types = _.uniq( _.pluck( field_data, "type" ) );
 
@@ -307,6 +307,10 @@ Collect.prototype.append = function( data ) {
 
 	_.each( field_data, function( field ) {
 		if ( typeof field.content !== "undefined" && field.content !== "" ) {
+			if ( field.order < 0 ) {
+				data = field.content + "\n" + data;
+				return;
+			}
 			data += "\n" + field.content;
 		}
 	} );
@@ -345,6 +349,16 @@ Collect.prototype.filterBroken = function( field_data ) {
 	return _.filter( field_data, function( field ) {
 		return ( "key" in field );
 	} );
+};
+
+Collect.prototype.sort = function( field_data ) {
+	if ( typeof config.fieldOrder === "undefined" || !config.fieldOrder ) {
+		return field_data;
+	}
+	_.each( field_data, function( field ) {
+		field.order = ( typeof config.fieldOrder[ field.name ] !== "undefined" ) ? config.fieldOrder[ field.name ] : 0;
+	} );
+	return field_data.sort( function ( a, b ) { return a.order > b.order; } );
 };
 
 module.exports = new Collect();
@@ -747,6 +761,8 @@ Scraper.prototype.wrapInHeadline = function( field ) {
 	var level = this.isHeadline( field );
 	if ( level ) {
 		field.content = "<h" + level + ">" + field.content + "</h" + level + ">";
+	} else {
+		field.content = "<p>" + field.content + "</p>";
 	}
 
 	return field;
@@ -783,7 +799,7 @@ Scraper.prototype.scrape = function( fields ) {
 			return field;
 		}
 
-		field.content = field.$el.find( "textarea[id^=acf]" ).val();
+		field.content = "<p>" + field.$el.find( "textarea[id^=acf]" ).val() + "</p>";
 
 		return field;
 	} );


### PR DESCRIPTION
This PR can be summarized in the following changelog entry:

* New filter to adjust field order
* Possibility to prepend field content to WordPress post_content using negative field order
* Wrap textarea and non headline text content in paragraphs 