### PR TITLE
PHPCS: Update to use YoastCS 1.0 / WPCS 1.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -122,23 +122,10 @@
 	#############################################################################
 	-->
 
-	<!-- Temporarily excluded due to a bug in WPCS.
-		 The bug has been addressed and will be fixed in WPCS 1.0.0.
-		 WPCS PR: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/1356
-	-->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound">
-		<exclude-pattern>/tests/php/unit/Dependencies/yoast-seo-dependency-test\.php$</exclude-pattern>
-	</rule>
-
 	<!-- Temporarily exceptions. These should be fixed.
 		 Ticket: https://github.com/Yoast/yoast-acf-analysis/issues/152 -->
 	<rule ref="Generic.Commenting.DocComment.MissingShort">
 		<type>warning</type>
-	</rule>
-
-	<rule ref="Generic.Commenting.DocComment">
-		<!-- This exclusion is related to a PHPCS bug which will be fixed in PHPCS 3.3.1. -->
-		<exclude name="Generic.Commenting.DocComment.SpacingBeforeTags"/>
 	</rule>
 	<rule ref="Squiz.Commenting.ClassComment.Missing">
 		<exclude-pattern>/tests/php/unit/*\.php$</exclude-pattern>

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "brain/monkey": "2.*",
     "phpunit/phpunit": "5.*",
     "roave/security-advisories": "dev-master",
-    "yoast/yoastcs": "~0.5.0",
+    "yoast/yoastcs": "^1.0",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cd5d5fade919c9267fdead7b008f576",
+    "content-hash": "83aa74ee584470d6b34beb0d05aaa5a4",
     "packages": [
         {
             "name": "composer/installers",
@@ -577,6 +577,105 @@
             ],
             "description": "Official version of pdepend to be handled with Composer",
             "time": "2017-12-13T13:21:38+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "8.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "PHPCompatibility\\": "PHPCompatibility/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-07-17T13:42:26+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b26c84df3ec1d4850d0f22264a4a16482a171996",
+                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^8.1"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for WordPress projects.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2018-07-16T22:10:02+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1295,17 +1394,6 @@
         {
             "name": "roave/security-advisories",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "0e4ea9f9e1fd3c6a563524f8f399696d98c7c85a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0e4ea9f9e1fd3c6a563524f8f399696d98c7c85a",
-                "reference": "0e4ea9f9e1fd3c6a563524f8f399696d98c7c85a",
-                "shasum": ""
-            },
             "conflict": {
                 "3f/pygmentize": "<1.2",
                 "adodb/adodb-php": "<5.20.12",
@@ -1346,15 +1434,16 @@
                 "gregwar/rst": "<1.0.3",
                 "guzzlehttp/guzzle": ">=6,<6.2.1|>=4.0.0-rc2,<4.2.4|>=5,<5.3.1",
                 "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
+                "illuminate/cookie": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.42|>=5.6,<5.6.30",
                 "illuminate/database": ">=4,<4.0.99|>=4.1,<4.1.29",
                 "illuminate/encryption": ">=4,<=4.0.11|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
                 "joomla/session": "<1.3.1",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
-                "laravel/framework": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.40|>=5.6,<5.6.15",
+                "laravel/framework": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.42|>=5.6,<5.6.30",
                 "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
-                "magento/magento1ce": ">=1.5.0.1,<1.9.3.2",
+                "magento/magento1ce": "<1.9.3.9",
                 "magento/magento1ee": ">=1.9,<1.14.3.2",
-                "magento/magento2ce": ">=2,<2.2",
+                "magento/product-community-edition": ">=2,<2.2.5",
                 "monolog/monolog": ">=1.8,<1.12",
                 "namshi/jose": "<2.2",
                 "onelogin/php-saml": "<2.10.4",
@@ -1385,10 +1474,12 @@
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
                 "stormpath/sdk": ">=0,<9.9.99",
                 "swiftmailer/swiftmailer": ">=4,<5.4.5",
+                "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
+                "sylius/sylius": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
                 "symfony/dependency-injection": ">=2,<2.0.17",
                 "symfony/form": ">=2.3,<2.3.35|>=2.4,<2.6.12|>=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/framework-bundle": ">=2,<2.3.18|>=2.4,<2.4.8|>=2.5,<2.5.2",
-                "symfony/http-foundation": ">=2,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/http-foundation": ">=2,<2.7.49|>=2.8,<2.8.44|>=3,<3.3.18|>=3.4,<3.4.14|>=4,<4.0.14|>=4.1,<4.1.3",
                 "symfony/http-kernel": ">=2,<2.3.29|>=2.4,<2.5.12|>=2.6,<2.6.8",
                 "symfony/intl": ">=2.7,<2.7.38|>=2.8,<2.8.31|>=3,<3.2.14|>=3.3,<3.3.13",
                 "symfony/routing": ">=2,<2.0.19",
@@ -1399,7 +1490,7 @@
                 "symfony/security-guard": ">=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/security-http": ">=2.3,<2.3.41|>=2.4,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
                 "symfony/serializer": ">=2,<2.0.11",
-                "symfony/symfony": ">=2,<2.7.48|>=2.8,<2.8.41|>=3,<3.3.17|>=3.4,<3.4.11|>=4,<4.0.11",
+                "symfony/symfony": ">=2,<2.7.49|>=2.8,<2.8.44|>=3,<3.3.18|>=3.4,<3.4.14|>=4,<4.0.14|>=4.1,<4.1.3",
                 "symfony/translation": ">=2,<2.0.17",
                 "symfony/validator": ">=2,<2.0.24|>=2.1,<2.1.12|>=2.2,<2.2.5|>=2.3,<2.3.3",
                 "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
@@ -1408,7 +1499,8 @@
                 "thelia/thelia": ">=2.1,<2.1.2|>=2.1.0-beta1,<2.1.3",
                 "titon/framework": ">=0,<9.9.99",
                 "twig/twig": "<1.20",
-                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.22|>=8,<8.7.5",
+                "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.30|>=8,<8.7.17|>=9,<9.3.2",
+                "typo3/cms-core": ">=8,<8.7.17|>=9,<9.3.2",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
                 "willdurand/js-translation-bundle": "<2.1.1",
@@ -1424,9 +1516,10 @@
                 "zendframework/zend-captcha": ">=2,<2.4.9|>=2.5,<2.5.2",
                 "zendframework/zend-crypt": ">=2,<2.4.9|>=2.5,<2.5.2",
                 "zendframework/zend-db": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.10|>=2.3,<2.3.5",
-                "zendframework/zend-diactoros": ">=1,<1.0.4",
+                "zendframework/zend-diactoros": ">=1,<1.8.4",
+                "zendframework/zend-feed": ">=1,<2.10.3",
                 "zendframework/zend-form": ">=2,<2.2.7|>=2.3,<2.3.1",
-                "zendframework/zend-http": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.3,<2.3.8|>=2.4,<2.4.1",
+                "zendframework/zend-http": ">=1,<2.8.1",
                 "zendframework/zend-json": ">=2.1,<2.1.6|>=2.2,<2.2.6",
                 "zendframework/zend-ldap": ">=2,<2.0.99|>=2.1,<2.1.99|>=2.2,<2.2.8|>=2.3,<2.3.3",
                 "zendframework/zend-mail": ">=2,<2.4.11|>=2.5,<2.7.2",
@@ -1435,7 +1528,7 @@
                 "zendframework/zend-validator": ">=2.3,<2.3.6",
                 "zendframework/zend-view": ">=2,<2.2.7|>=2.3,<2.3.1",
                 "zendframework/zend-xmlrpc": ">=2.1,<2.1.6|>=2.2,<2.2.6",
-                "zendframework/zendframework": ">=2,<2.4.11|>=2.5,<2.5.1",
+                "zendframework/zendframework": "<2.5.1",
                 "zendframework/zendframework1": "<1.12.20",
                 "zendframework/zendopenid": ">=2,<2.0.2",
                 "zendframework/zendxml": ">=1,<1.0.1",
@@ -1457,7 +1550,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2018-06-08T09:55:50+00:00"
+            "time": "2018-08-14T15:39:17+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1974,16 +2067,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266"
+                "reference": "628a481780561150481a9ec74709092b9759b3ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
-                "reference": "d86873af43b4aa9d1f39a3601cc0cfcf02b25266",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
+                "reference": "628a481780561150481a9ec74709092b9759b3ec",
                 "shasum": ""
             },
             "require": {
@@ -2021,20 +2114,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-06-06T23:58:19+00:00"
+            "time": "2018-07-26T23:47:18+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v3.4.11",
+            "version": "v3.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "73e055cf2e6467715f187724a0347ea32079967c"
+                "reference": "7b08223b7f6abd859651c56bcabf900d1627d085"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/73e055cf2e6467715f187724a0347ea32079967c",
-                "reference": "73e055cf2e6467715f187724a0347ea32079967c",
+                "url": "https://api.github.com/repos/symfony/config/zipball/7b08223b7f6abd859651c56bcabf900d1627d085",
+                "reference": "7b08223b7f6abd859651c56bcabf900d1627d085",
                 "shasum": ""
             },
             "require": {
@@ -2085,11 +2178,11 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-14T16:49:53+00:00"
+            "time": "2018-07-26T11:19:56+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.3.17",
+            "version": "v3.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
@@ -2159,16 +2252,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.11",
+            "version": "v3.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0"
+                "reference": "a59f917e3c5d82332514cb4538387638f5bde2d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0",
-                "reference": "8e03ca3fa52a0f56b87506f38cf7bd3f9442b3a0",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a59f917e3c5d82332514cb4538387638f5bde2d6",
+                "reference": "a59f917e3c5d82332514cb4538387638f5bde2d6",
                 "shasum": ""
             },
             "require": {
@@ -2205,29 +2298,32 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-05-16T08:49:21+00:00"
+            "time": "2018-07-26T11:19:56+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae"
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
-                "reference": "7cc359f1b7b80fc25ed7796be7d96adc9b354bae",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
+                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -2260,7 +2356,7 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-04-30T19:57:29+00:00"
+            "time": "2018-08-06T14:22:27+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2368,77 +2464,28 @@
             "time": "2016-11-23T20:04:58+00:00"
         },
         {
-            "name": "wimg/php-compatibility",
-            "version": "8.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wimg/PHPCompatibility.git",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wimg/PHPCompatibility/zipball/4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
-                "reference": "4ac01e4fe8faaa4f8d3b3cd06ea92e5418ce472e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.2 || ^3.0.2"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
-            },
-            "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                }
-            ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards"
-            ],
-            "time": "2017-12-27T21:58:38+00:00"
-        },
-        {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.14.1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "cf6b310caad735816caef7573295f8a534374706"
+                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/cf6b310caad735816caef7573295f8a534374706",
-                "reference": "cf6b310caad735816caef7573295f8a534374706",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/539c6d74e6207daa22b7ea754d6f103e9abb2755",
+                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
                 "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "*"
+            },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2457,31 +2504,35 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-02-16T01:57:48+00:00"
+            "time": "2018-07-25T18:10:35+00:00"
         },
         {
             "name": "yoast/yoastcs",
-            "version": "0.5",
+            "version": "1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "fad5e7c969a7df04fae50bca382c28fe273dbfc0"
+                "reference": "3b3498c1b057746003eefca90c10080cd606a29e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/fad5e7c969a7df04fae50bca382c28fe273dbfc0",
-                "reference": "fad5e7c969a7df04fae50bca382c28fe273dbfc0",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/3b3498c1b057746003eefca90c10080cd606a29e",
+                "reference": "3b3498c1b057746003eefca90c10080cd606a29e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
+                "phpcompatibility/phpcompatibility-wp": "^1.0.0",
                 "phpmd/phpmd": "^2.2.3",
-                "squizlabs/php_codesniffer": "^3.2.0",
-                "wimg/php-compatibility": "^8.1.0",
-                "wp-coding-standards/wpcs": "~0.14.0"
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "wp-coding-standards/wpcs": "^1.0.0"
+            },
+            "require-dev": {
+                "phpcompatibility/php-compatibility": "^8.2.0",
+                "roave/security-advisories": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2502,7 +2553,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2018-01-25T11:03:34+00:00"
+            "time": "2018-08-24T09:04:56+00:00"
         }
     ],
     "aliases": [],

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -65,5 +65,4 @@ class Yoast_ACF_Analysis_Assets {
 			wp_localize_script( 'yoast-acf-analysis-term', 'YoastACFAnalysisConfig', $config->to_array() );
 		}
 	}
-
 }

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -99,7 +99,6 @@ class Yoast_ACF_Analysis_Configuration {
 		}
 
 		return $this->blacklist_type;
-
 	}
 
 	/**

--- a/inc/configuration/string-store.php
+++ b/inc/configuration/string-store.php
@@ -72,5 +72,4 @@ class Yoast_ACF_Analysis_String_Store {
 	public function to_array() {
 		return $this->items;
 	}
-
 }

--- a/inc/dependencies/dependency-acf.php
+++ b/inc/dependencies/dependency-acf.php
@@ -43,5 +43,4 @@ final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Depe
 
 		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );
 	}
-
 }

--- a/inc/dependencies/dependency-interface.php
+++ b/inc/dependencies/dependency-interface.php
@@ -9,6 +9,7 @@
  * Interface Yoast_ACF_Analysis_Dependency.
  */
 interface Yoast_ACF_Analysis_Dependency {
+
 	/**
 	 * Checks if this dependency is met.
 	 *

--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -93,5 +93,4 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 	private function has_required_version() {
 		return -1 !== version_compare( $this->get_major_version( WPSEO_VERSION ), self::MINIMAL_REQUIRED_VERSION );
 	}
-
 }

--- a/inc/registry.php
+++ b/inc/registry.php
@@ -37,5 +37,4 @@ class Yoast_ACF_Analysis_Registry {
 	public function get( $id ) {
 		return array_key_exists( $id, $this->storage ) ? $this->storage[ $id ] : null;
 	}
-
 }

--- a/inc/requirements.php
+++ b/inc/requirements.php
@@ -50,5 +50,4 @@ class Yoast_ACF_Analysis_Requirements {
 
 		return $all_are_met;
 	}
-
 }

--- a/tests/js/system/data/test-data-loader-functions.php
+++ b/tests/js/system/data/test-data-loader-functions.php
@@ -28,5 +28,4 @@ function yoast_acf_analysis_test_data_loader() {
 	}
 
 	require_once AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . '/tests/js/system/data/acf' . $version . '.php';
-
 }

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -81,7 +81,6 @@ class Configuration_Test extends \PHPUnit_Framework_TestCase {
 			->andReturn( $blacklist_type2 );
 
 		$this->assertSame( $blacklist_type2, $configuration->get_blacklist_type() );
-
 	}
 
 	public function testBlacklistTypeFilterInvalid() {
@@ -298,6 +297,5 @@ class Configuration_Test extends \PHPUnit_Framework_TestCase {
 			->andReturn( '' );
 
 		$this->assertSame( $store, $configuration->get_field_selectors() );
-
 	}
 }

--- a/tests/php/unit/Configuration/string-store-test.php
+++ b/tests/php/unit/Configuration/string-store-test.php
@@ -25,7 +25,6 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 		$store->add( $type );
 
 		$this->assertSame( [ $type ], $store->to_array() );
-
 	}
 
 	public function testAddSame() {
@@ -37,7 +36,6 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 		$store->add( $type );
 
 		$this->assertSame( [ $type ], $store->to_array() );
-
 	}
 
 	public function testAddMultiple() {
@@ -50,7 +48,6 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 		$store->add( $type_b );
 
 		$this->assertSame( [ $type_a, $type_b ], $store->to_array() );
-
 	}
 
 	public function testAddMultipleSorting() {
@@ -63,7 +60,6 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 		$store->add( $type_b );
 
 		$this->assertSame( [ $type_b, $type_a ], $store->to_array() );
-
 	}
 
 	public function testAddNonString() {
@@ -72,7 +68,6 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 
 		$this->assertFalse( $store->add( 999 ) );
 		$this->assertEmpty( $store->to_array() );
-
 	}
 
 	public function testRemove() {
@@ -94,7 +89,6 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 		$store->remove( $type_b );
 
 		$this->assertEmpty( $store->to_array() );
-
 	}
 
 	public function testRemoveNonString() {
@@ -103,7 +97,6 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 		$store->add( '999' );
 
 		$this->assertFalse( $store->remove( 999 ) );
-
 	}
 
 	public function testRemoveNonExist() {
@@ -111,7 +104,5 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 		$store = $this->getStore();
 
 		$this->assertFalse( $store->remove( 'test' ) );
-
 	}
-
 }

--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -5,6 +5,7 @@ namespace Yoast\AcfAnalysis\Tests\Dependencies;
 use Brain\Monkey;
 
 class ACF_Dependency_Test extends \PHPUnit_Framework_TestCase {
+
 	/**
 	 * Set up test fixtures.
 	 */

--- a/tests/php/unit/Doubles/failing-dependency.php
+++ b/tests/php/unit/Doubles/failing-dependency.php
@@ -3,6 +3,7 @@
 namespace Yoast\AcfAnalysis\Tests\Doubles;
 
 class Failing_Dependency implements \Yoast_ACF_Analysis_Dependency {
+
 	/**
 	 * Checks if this dependency is met.
 	 *

--- a/tests/php/unit/Doubles/passing-dependency.php
+++ b/tests/php/unit/Doubles/passing-dependency.php
@@ -3,6 +3,7 @@
 namespace Yoast\AcfAnalysis\Tests\Doubles;
 
 class Passing_Dependency implements \Yoast_ACF_Analysis_Dependency {
+
 	/**
 	 * Checks if this dependency is met.
 	 *

--- a/tests/php/unit/main-test.php
+++ b/tests/php/unit/main-test.php
@@ -32,6 +32,5 @@ class Main_Test extends \PHPUnit_Framework_TestCase {
 
 		$this->assertNotSame( 'Invalid Config', $registry->get( 'config' ) );
 		$this->assertInstanceOf( \Yoast_ACF_Analysis_Configuration::class, $registry->get( 'config' ) );
-
 	}
 }

--- a/tests/php/unit/registry-test.php
+++ b/tests/php/unit/registry-test.php
@@ -22,7 +22,6 @@ class Registry_Test extends \PHPUnit_Framework_TestCase {
 		);
 
 		$this->assertSame( $first, $second );
-
 	}
 
 	public function testAdd() {
@@ -37,7 +36,5 @@ class Registry_Test extends \PHPUnit_Framework_TestCase {
 		$registry->add( $id, $content );
 
 		$this->assertSame( $content, $registry->get( $id ) );
-
 	}
-
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

### Composer: require YoastCS 1.0

This updates:
* PHP_CodeSniffer from v 3.3.0 => 3.3.1
* WordPressCS from v 0.14.1 => 1.0.0
* PHPCompatibility from v 8.1.0 => 8.2.0

This adds:
* PHPCompatibilityWP at v 1.0.0

The following dependencies of PHP Mess Detector, which is part of YoastCS, have also been updated:
* Symfony Polyfill Ctype from v 1.8.0 => 1.9.0
* Symfony Filesystem from v 3.4.11 => 3.4.14
* Symfony Dependency Injection from v 3.3.17 => 3.3.18
* Symfony Config from 3.4.11 => 3.4.14

Additionally, the Roave Security Advisories have been brought up to date.

### PHPCS: update ruleset for YoastCS/WPCS 1.0.0/PHPCS 3.3.1

* Remove a directive which has to do with a bug in WPCS which has been fixed in version 1.0.0.
* Remove a directive which has to do with a bug in PHPCS which has been fixed in version 3.3.1.

### CS: minor whitespace fixes to comply with YoastCS 1.0.0 

## Test instructions

This PR can be tested by following these steps:

* All should be fine if the Travis build passes.
* If you really want to test locally:
    - Run `composer install` to update your locally installed dependencies.
    - Run `composer check-cs` to see it in action. For the results, you should just see some warnings about missing docblock descriptions - see technical-debt issue #152.