### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,16 @@ branches:
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
-      env: WP_VERSION=4.9 WP_MULTISITE=1 PHPCS=1 CHECKJS=1 PHPUNIT=1 TRAVIS_NODE_VERSION=node
+    - php: 7.3
+      env: WP_VERSION=5.0 WP_MULTISITE=1 PHPCS=1 CHECKJS=1 PHPUNIT=1 TRAVIS_NODE_VERSION=node
     - php: 5.2
       dist: precise
     - php: 5.3
       dist: precise
     - php: 5.6
-      env: PHPUNIT=1 WP_VERSION=4.7
-    - php: 7.0
       env: PHPUNIT=1 WP_VERSION=4.8
+    - php: 7.0
+      env: PHPUNIT=1 WP_VERSION=4.9
     - php: nightly
       env: PHPUNIT=1 WP_VERSION=master
 
@@ -76,4 +76,4 @@ script:
 - if [[ "$PHPCS" == "1" ]]; then vendor/bin/phpcs -q ./tests/ --runtime-set ignore_warnings_on_exit 1 --runtime-set testVersion 5.6-; fi
 - if [[ "$CHECKJS" == "1" ]]; then grunt check; fi
 - if [[ "$PHPUNIT" == "1" ]]; then composer test; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* This plugin has been tested with PHP 7.3.

## Relevant technical choices:

Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and builds haven't been tested against PHP 7.3 for months now.

As of this week, Travis has (finally) made a PHP 7.3 alias available now RC3 is out, so I've updated the highest PHP version to test against to PHP 7.3/WP 5.0 so there won't be any unwelcome surprises when PHP 7.3/WP 5.0 comes out.

Note: I've adjusted the WP versions for the other unit test builds to match, i.e. upped them one minor.


## Test instructions

This PR can be tested by following these steps:

* Check if the Travis build for PHP 7.3 has passed.
