### PR TITLE
Travis: re-enable running the unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,9 +59,8 @@
     "classmap": [ "inc" ]
   },
   "autoload-dev": {
-    "psr-4": {
-      "Yoast\\AcfAnalysis\\Tests\\": "tests/php/unit"
-    },
+    "classmap": [ "tests/php/unit" ],
+    "exclude-from-classmap": ["/tests/php/unit/Dependencies/acf.php"],
     "files": [
       "tests/js/system/data/test-data-loader-functions.php"
     ]

--- a/tests/php/phpunit.xml.dist
+++ b/tests/php/phpunit.xml.dist
@@ -9,7 +9,7 @@
          verbose="true">
     <testsuites>
         <testsuite name="unit">
-            <directory suffix="Test.php">unit</directory>
+            <directory suffix="test.php">unit</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

Looks like PR #142 inadvertently disabled the unit tests as the test files are no longer PSR-4 compliant and the name suffix check done by PHPUnit may or may not be case-sensitive. Mea culpa.

These minor changes should re-enable them.

Note: The `acf.php` dummy file is explicitly excluded from being autoloaded as the `Yoast_ACF_Analysis_Dependency_ACF` class does a [`class_exists()` without setting the `$autoload` parameter](http://php.net/manual/en/function.class-exists.php) to `false`.
As this may actually be advantageous in a situation were WP plugins are being installed via Composer, I've elected not to change that function call, but to exclude the test dummy file from the autoload class map instead.


## Test instructions

This PR can be tested by following these steps:

* Check the run logs for the Travis builds to see that the unit tests are being run again and/or try running the unit tests locally.

