### PR TITLE
PHPUnit: Move the config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ nightwatch.conf.js
 
 phpcs.xml
 .phpcs.xml
+phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
       "xrstf\\Composer52\\Generator::onPostInstallCmd"
     ],
     "test": [
-      "vendor/bin/phpunit --configuration tests/php/phpunit.xml.dist --colors=always"
+      "vendor/bin/phpunit --colors=always"
     ],
     "configure-phpcs": [
       "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,13 +9,13 @@
          verbose="true">
     <testsuites>
         <testsuite name="unit">
-            <directory suffix="test.php">unit</directory>
+            <directory suffix="test.php">tests/php/unit</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory suffix=".php">../../inc/</directory>
+            <directory suffix=".php">inc/</directory>
         </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

> If `phpunit.xml` or `phpunit.xml.dist` (in that order) exist in the current working directory and `--configuration` is not used, the configuration will be automatically read from that file.

From: https://phpunit.de/manual/6.5/en/organizing-tests.html#organizing-tests.xml-configuration

In other words, moving the `phpunit.xml.dist` file to the project root allows for running PHPUnit without passing `--configuration` and makes it more obvious that there are unit tests associated with the PHP code in this plugin.

Includes adding `phpunit.xml` to the `.gitignore` file to allow devs to use that file for their own custom configuration.

## Test instructions

This PR can be tested by following these steps:

* Check the Travis output to verify that the unit tests are still run correctly (compare against a previous build on `develop`).
* Try running the unit tests from the root of the repository using the `composer test` command.
