### PR TITLE
PHPCS ruleset: update the prefixes array

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -79,10 +79,13 @@
 		<properties>
 			<!-- Provide the prefixes to look for. -->
 			<property name="prefixes" type="array">
-				<element value="Yoast_ACF"/>
+				<!-- Temporarily allowed until the prefixes are fixed. -->
 				<element value="AC_Yoast"/>
 				<element value="AC_SEO"/>
 				<element value="ysacf"/>
+				<!-- These are the new prefixes which all code should comply with in the future. -->
+				<element value="yoast_acf"/>
+				<element value="Yoast\WP\ACF"/>
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

Update the prefixes array used by PHPCS to cover the new prefixes which should be used from now on for global structures as well as namespaced structures based on the agreed prefixes per September 2018.


## Test instructions

This PR can be tested by following these steps:

* _N/A_
