### PR TITLE
Composer: sync with other config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
+    "php": ">=5.2",
     "composer/installers": "~1.0",
     "xrstf/composer-php52": "1.*"
   },
@@ -75,20 +76,24 @@
       "xrstf\\Composer52\\Generator::onPostInstallCmd"
     ],
     "test": [
-      "vendor/bin/phpunit --colors=always"
+      "@php ./vendor/phpunit/phpunit/phpunit --colors=always"
     ],
     "configure-phpcs": [
-      "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+      "@config-yoastcs"
+    ],
+    "config-yoastcs": [
+      "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
     ],
     "check-cs": [
-      "\"vendor/bin/phpcs\" --ignore=./tests",
-      "\"vendor/bin/phpcs\" ./tests/ --runtime-set testVersion 5.6-"
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=./tests",
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/ --runtime-set testVersion 5.6-"
     ],
     "check-cs-errors": [
       "@check-cs"
     ],
     "fix-cs": [
-      "\"vendor/bin/phpcbf\""
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
     ]
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15063e45723e515d79123d8006afec0a",
+    "content-hash": "808cb710303fc217334ec4ff109373a1",
     "packages": [
         {
             "name": "composer/installers",
@@ -1397,6 +1397,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
         {
@@ -1454,12 +1455,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "344bf4ed1263c75e7f96b87b80c52e8373561e19"
+                "reference": "0e9deaa81b96fd55d9ba0fd9f5fa0353b7b79725"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/344bf4ed1263c75e7f96b87b80c52e8373561e19",
-                "reference": "344bf4ed1263c75e7f96b87b80c52e8373561e19",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/0e9deaa81b96fd55d9ba0fd9f5fa0353b7b79725",
+                "reference": "0e9deaa81b96fd55d9ba0fd9f5fa0353b7b79725",
                 "shasum": ""
             },
             "conflict": {
@@ -1554,7 +1555,7 @@
                 "shopware/shopware": "<5.3.7",
                 "silverstripe/cms": ">=3,<=3.0.11|>=3.1,<3.1.11",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": ">=3,<3.3",
+                "silverstripe/framework": ">=3,<3.6.7|>=3.7,<3.7.3|>=4,<4.0.7|>=4.1,<4.1.5|>=4.2,<4.2.4|>=4.3,<4.3.1",
                 "silverstripe/userforms": "<3",
                 "simple-updates/phpwhois": "<=1",
                 "simplesamlphp/saml2": "<1.10.6|>=2,<2.3.8|>=3,<3.1.4",
@@ -1650,7 +1651,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2019-02-05T19:58:17+00:00"
+            "time": "2019-02-20T16:25:00+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2664,7 +2665,9 @@
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.2"
+    },
     "platform-dev": {
         "php": ">=5.6.0"
     }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

I've done a compare between the `composer.json` config files in (nearly) all plugin repos.

This commit adds some additional properties to the config file to improve consistency with the other repos and predictability for devs.

* Adds an explicit minimum PHP version for `require`.
* Adds a `config-yoastcs` scripts for use by devs. The "old" version of this `configure-phpcs` was not in line with the other plugins, but has been left as an alias.
* Makes the existing scripts respect the PHP version Composer is run on.
     See Yoast/yoastcs#114 for a more detailed explanation.


## Test instructions

This PR can be tested by following these steps:

* Run `composer install`
* Run each of the scripts defined in the `composer.json` file in turn to see that all still works as expected.
