### PR TITLE
QA: use the most specific PHPUnit assertion possible

### DIFF
--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -59,7 +59,7 @@ class Configuration_Test extends \PHPUnit_Framework_TestCase {
 			$configuration->to_array()
 		);
 
-		$this->assertEquals( Filters\applied( 'acf/get_info' ), 1 );
+		$this->assertSame( Filters\applied( 'acf/get_info' ), 1 );
 	}
 
 	/**
@@ -78,7 +78,7 @@ class Configuration_Test extends \PHPUnit_Framework_TestCase {
 		);
 		$config        = $configuration->to_array();
 
-		$this->assertEquals( $acf_version, $config['acfVersion'] );
+		$this->assertSame( $acf_version, $config['acfVersion'] );
 	}
 
 	/**

--- a/tests/php/unit/Configuration/string-store-test.php
+++ b/tests/php/unit/Configuration/string-store-test.php
@@ -22,8 +22,11 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 	 * @return void
 	 */
 	public function testEmpty() {
-		$store = $this->getStore();
-		$this->assertEmpty( $store->to_array() );
+		$store  = $this->getStore();
+		$result = $store->to_array();
+
+		$this->assertInternalType( 'array', $result );
+		$this->assertEmpty( $result );
 	}
 
 	/**
@@ -101,7 +104,11 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 		$store = $this->getStore();
 
 		$this->assertFalse( $store->add( 999 ) );
-		$this->assertEmpty( $store->to_array() );
+
+		$result = $store->to_array();
+
+		$this->assertInternalType( 'array', $result );
+		$this->assertEmpty( $result );
 	}
 
 	/**
@@ -127,7 +134,10 @@ class String_Store_Test extends \PHPUnit_Framework_TestCase {
 
 		$store->remove( $type_b );
 
-		$this->assertEmpty( $store->to_array() );
+		$result = $store->to_array();
+
+		$this->assertInternalType( 'array', $result );
+		$this->assertEmpty( $result );
 	}
 
 	/**

--- a/tests/php/unit/main-test.php
+++ b/tests/php/unit/main-test.php
@@ -42,7 +42,9 @@ class Main_Test extends \PHPUnit_Framework_TestCase {
 		$testee = new \AC_Yoast_SEO_ACF_Content_Analysis();
 		$testee->boot();
 
-		$this->assertNotSame( 'Invalid Config', $registry->get( 'config' ) );
-		$this->assertInstanceOf( \Yoast_ACF_Analysis_Configuration::class, $registry->get( 'config' ) );
+		$result = $registry->get( 'config' );
+
+		$this->assertNotSame( 'Invalid Config', $result );
+		$this->assertInstanceOf( \Yoast_ACF_Analysis_Configuration::class, $result );
 	}
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

This is a long established best practice.

PHPUnit contains a variety of assertions and the ones available have been extended  hugely over the years.
To have the most reliable tests, the most specific assertion should be used.

This implements this for the Yoast ACF Analysis plugin.

Refs:
* https://phpunit.de/manual/4.8/en/appendixes.assertions.html
* https://phpunit.readthedocs.io/en/7.5/assertions.html#

Most notably, this changes calls to `assertEquals()` to `assertSame()`, where `assertEquals()` does a loose type comparison and `assertSame()` does a strict type comparison.

Refs:
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals
* https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame

It also includes a stricter check on arrays which are supposed to be empty and removes a duplicate function call.


## Test instructions

This PR can be tested by following these steps:
* If the Travis unit test builds pass, we're good.