### PR TITLE
QA: Make the unit tests PHPUnit cross-version compatible

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -107,4 +107,19 @@
 		</properties>
 	</rule>
 
+
+	<!--
+	#############################################################################
+	TEMPORARY ADJUSTMENTS
+	Adjustments which should be removed once the associated issue has been resolved.
+	#############################################################################
+	-->
+
+	<!-- Namespaced test classes imported via a use statement are not yet correctly excluded
+		 by WPCS. This will most likely be fixed once PHPCS 3.5.0 has been released and
+		 WPCS has upgraded to that version. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound">
+		<exclude-pattern>/tests/php/unit/Dependencies/yoast-seo-dependency-test\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
   "require-dev": {
     "php": ">=5.6.0",
     "brain/monkey": "2.*",
-    "phpunit/phpunit": "5.*",
+    "phpunit/phpunit": "^5.4 || ^6.0 || ^7.0",
     "yoast/yoastcs": "^1.2.2"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2297acde4cb4a464398ef110b2c7648a",
+    "content-hash": "bbd12af7d95ecac09f1c85b5d34f7adc",
     "packages": [
         {
             "name": "composer/installers",
@@ -2264,7 +2264,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.26",
+            "version": "v3.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
-         backupGlobals="false"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="unit">
-            <directory suffix="test.php">tests/php/unit</directory>
-        </testsuite>
-    </testsuites>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.5/phpunit.xsd"
+		backupGlobals="false"
+		beStrictAboutCoversAnnotation="true"
+		beStrictAboutOutputDuringTests="true"
+		beStrictAboutTestsThatDoNotTestAnything="true"
+		beStrictAboutTodoAnnotatedTests="true"
+		bootstrap="vendor/autoload.php"
+		verbose="true"
+	>
+	<testsuites>
+		<testsuite name="unit">
+			<directory suffix="test.php">tests/php/unit</directory>
+		</testsuite>
+	</testsuites>
 
-    <filter>
-        <whitelist>
-            <directory suffix=".php">inc/</directory>
-        </whitelist>
-    </filter>
+	<filter>
+		<whitelist>
+			<directory suffix=".php">inc/</directory>
+		</whitelist>
+	</filter>
 </phpunit>

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -5,11 +5,12 @@ namespace Yoast\AcfAnalysis\Tests\Configuration;
 use Brain\Monkey;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Configuration_Test
  */
-class Configuration_Test extends \PHPUnit_Framework_TestCase {
+class Configuration_Test extends TestCase {
 
 	/**
 	 * Sets up test fixtures.

--- a/tests/php/unit/Configuration/string-store-test.php
+++ b/tests/php/unit/Configuration/string-store-test.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\AcfAnalysis\Tests\Configuration;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class String_Store_Test
  */
-class String_Store_Test extends \PHPUnit_Framework_TestCase {
+class String_Store_Test extends TestCase {
 
 	/**
 	 * Gets the blacklist string store.

--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -3,11 +3,12 @@
 namespace Yoast\AcfAnalysis\Tests\Dependencies;
 
 use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ACF_Dependency_Test
  */
-class ACF_Dependency_Test extends \PHPUnit_Framework_TestCase {
+class ACF_Dependency_Test extends TestCase {
 
 	/**
 	 * Sets up test fixtures.

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -3,11 +3,12 @@
 namespace Yoast\AcfAnalysis\Tests\Dependencies;
 
 use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Yoast_SEO_Dependency_Test*
  */
-class Yoast_SEO_Dependency_Test extends \PHPUnit_Framework_TestCase {
+class Yoast_SEO_Dependency_Test extends TestCase {
 
 	/**
 	 * Whether or not to preserve the global state.

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -4,11 +4,12 @@ namespace Yoast\AcfAnalysis\Tests\Assets;
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Assets_Test
  */
-class Assets_Test extends \PHPUnit_Framework_TestCase {
+class Assets_Test extends TestCase {
 
 	/**
 	 * Whether or not to preserve the global state.

--- a/tests/php/unit/main-test.php
+++ b/tests/php/unit/main-test.php
@@ -3,11 +3,12 @@
 namespace Yoast\AcfAnalysis\Tests;
 
 use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class Main_Test
  */
-class Main_Test extends \PHPUnit_Framework_TestCase {
+class Main_Test extends TestCase {
 
 	/**
 	 * Sets up test fixtures.

--- a/tests/php/unit/registry-test.php
+++ b/tests/php/unit/registry-test.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\AcfAnalysis\Tests\Configuration;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class Registry_Test
  */
-class Registry_Test extends \PHPUnit_Framework_TestCase {
+class Registry_Test extends TestCase {
 
 	/**
 	 * Tests that the singleton instance is properly set and that every call to the registry, is the same instance.

--- a/tests/php/unit/requirements-test.php
+++ b/tests/php/unit/requirements-test.php
@@ -5,13 +5,14 @@ namespace Yoast\AcfAnalysis\Tests\Configuration;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use Brain\Monkey\Filters;
+use PHPUnit\Framework\TestCase;
 use Yoast\AcfAnalysis\Tests\Doubles\Passing_Dependency;
 use Yoast\AcfAnalysis\Tests\Doubles\Failing_Dependency;
 
 /**
  * Class Requirements_Test
  */
-class Requirements_Test extends \PHPUnit_Framework_TestCase {
+class Requirements_Test extends TestCase {
 
 	/**
 	 * Sets up test fixtures.


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

The unit tests for ACF have a minimum PHP requirement of PHP 5.6 due to the dependency on BrainMonkey.

At this time, the only PHPUnit version supported was PHPUnit 5.x. However, as the minimum PHP requirement is 5.6 anyway, it is quite easy to make the unit tests compatible with PHPUnit 5.x - 7.x.

PHPUnit 5.x will run on PHP 5.6 - 7.1.
PHPUnit 6.x will run on PHP 7.0 - 7.2.
PHPUnit 7.x will run on PHP 7.1 - 7.3.

For now, PHPUnit 7.x will also work fine for PHP 7.4 (unstable), so supporting PHPUnit 8.x is not yet necessary.
Ref: https://phpunit.de/supported-versions.html

Background:
The classes in PHPUnit have been renamed to namespaced classes.
The namespaced alias for the TestCase class is available as of PHPUnit 5.4 and as of PHPUnit 6.0, the non-namespaced versions are no longer available.

As PHPUnit 5.4 is available to use on PHP 5.6, all that is needed to make the test suite compatible with PHPUnit 5.x - 7.x, is to switch over to using the namespaced PHPUnit classes.

Includes a minor tweak to the PHPCS ruleset to get round a "modern PHP not (yet) fully accounted for correctly" bug in WPCS.

### CI/QA: minor tweaks to the phpunit.xml.dist file

The specs for the `phpunit.xml.dist` file have changed numerous times over the years with new options being added and outdated options being removed.
These specs are contained in a schema XSD file for each minor PHPUnit version.

This commit:
* Updates the link to the XSD schema used;
* Makes the dependency on the Composer autoload file as a test bootstrap explicit.
* Fixes the indentation to tabs.



## Test instructions

This PR can be tested by following these steps:
* With local installs of various PHPUnit (phars) versions, run `phpunit`.
* Alternatively, run a `composer update phpunit/phpunit` on various PHP versions to install higher versions of PHPUnit, then run `composer test`. Rinse repeat for other PHP versions.