### PR TITLE
Travis/Unit tests: remove WP download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,22 +22,21 @@ matrix:
   fast_finish: true
   include:
     - php: 7.3
-      env: WP_VERSION=5.0 WP_MULTISITE=1 PHPCS=1 CHECKJS=1 PHPUNIT=1 SECURITY=1 TRAVIS_NODE_VERSION=node
+      env: PHPCS=1 CHECKJS=1 PHPUNIT=1 SECURITY=1 TRAVIS_NODE_VERSION=node
     - php: 5.2
       dist: precise
     - php: 5.3
       dist: precise
     - php: 5.6
-      env: PHPUNIT=1 WP_VERSION=4.8
+      env: PHPUNIT=1
     - php: 7.0
-      env: PHPUNIT=1 WP_VERSION=4.9
+      env: PHPUNIT=1
     - php: "7.4snapshot"
-      env: PHPUNIT=1 WP_VERSION=master
+      env: PHPUNIT=1
 
   allow_failures:
     # Allow failures for unstable builds.
     - php: "7.4snapshot"
-    - env: WP_VERSION=master
 
 before_install:
 - export SECURITYCHECK_DIR=/tmp/security-checker
@@ -50,24 +49,6 @@ install:
 - if [[ "$CHECKJS" == "1" ]]; then yarn global add grunt-cli; fi
 - if [[ "$CHECKJS" == "1" ]]; then yarn install; fi
 - if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://get.sensiolabs.org/security-checker.phar && chmod +x $SECURITYCHECK_DIR/security-checker.phar;fi
-
-before_script:
-- |
-  if [[ "$PHPUNIT" == "1" ]]; then
-    PLUGIN_SLUG=$(basename $(pwd))
-    export WP_DEVELOP_DIR=/tmp/wordpress/
-    git clone --depth=50 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
-    cd ..
-    cp -r "$PLUGIN_SLUG" "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-    cd /tmp/wordpress/
-    cp wp-tests-config-sample.php wp-tests-config.php
-    sed -i "s/youremptytestdbnamehere/wordpress_tests/" wp-tests-config.php
-    sed -i "s/yourusernamehere/travis/" wp-tests-config.php
-    sed -i "s/yourpasswordhere//" wp-tests-config.php
-    mysql -e "CREATE DATABASE wordpress_tests;" -uroot
-    cd "/tmp/wordpress/src/wp-content/plugins/$PLUGIN_SLUG"
-    phpenv rehash
-  fi
 
 script:
 # Exclude tests directory from linting for PHP 5.2/3


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

The unit tests for the ACF plugin are not dependent on WP being loaded as `Brain\Monkey` is used to mock WP, so there is no need to download and install WP during the CI run.


## Test instructions

This PR can be tested by following these steps:

* Check the Travis output to verify that the unit tests are still being run and pass.