### PR TITLE
CS/QA: add minimalist @covers tags to all tests

### DIFF
--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class Configuration_Test.
+ *
+ * @covers Yoast_ACF_Analysis_Configuration
  */
 class Configuration_Test extends TestCase {
 

--- a/tests/php/unit/Configuration/string-store-test.php
+++ b/tests/php/unit/Configuration/string-store-test.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class String_Store_Test.
+ *
+ * @covers Yoast_ACF_Analysis_String_Store
  */
 class String_Store_Test extends TestCase {
 

--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class ACF_Dependency_Test.
+ *
+ * @covers Yoast_ACF_Analysis_Dependency_ACF
  */
 class ACF_Dependency_Test extends TestCase {
 

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class Yoast_SEO_Dependency_Test.
+ *
+ * @covers Yoast_ACF_Analysis_Dependency_Yoast_SEO
  */
 class Yoast_SEO_Dependency_Test extends TestCase {
 

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class Assets_Test.
+ *
+ * @covers Yoast_ACF_Analysis_Assets
  */
 class Assets_Test extends TestCase {
 

--- a/tests/php/unit/main-test.php
+++ b/tests/php/unit/main-test.php
@@ -33,6 +33,8 @@ class Main_Test extends TestCase {
 	/**
 	 * Tests invalid configurations.
 	 *
+	 * @covers Yoast_ACF_Analysis_Configuration
+	 *
 	 * @return void
 	 */
 	public function testInvalidConfig() {

--- a/tests/php/unit/registry-test.php
+++ b/tests/php/unit/registry-test.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Class Registry_Test.
+ *
+ * @covers Yoast_ACF_Analysis_Registry
  */
 class Registry_Test extends TestCase {
 

--- a/tests/php/unit/requirements-test.php
+++ b/tests/php/unit/requirements-test.php
@@ -35,6 +35,8 @@ class Requirements_Test extends TestCase {
 	/**
 	 * Tests the situation where there are no dependencies.
 	 *
+	 * @covers Yoast_ACF_Analysis_Requirements::are_met
+	 *
 	 * @return void
 	 */
 	public function testNoDependencies() {
@@ -44,6 +46,9 @@ class Requirements_Test extends TestCase {
 
 	/**
 	 * Tests that requirements are met when a valid dependency is added.
+	 *
+	 * @covers Yoast_ACF_Analysis_Requirements::add_dependency
+	 * @covers Yoast_ACF_Analysis_Requirements::are_met
 	 *
 	 * @return void
 	 */
@@ -57,6 +62,9 @@ class Requirements_Test extends TestCase {
 	/**
 	 * Tests that requirements are not met when an invalid dependency is added.
 	 *
+	 * @covers Yoast_ACF_Analysis_Requirements::add_dependency
+	 * @covers Yoast_ACF_Analysis_Requirements::are_met
+	 *
 	 * @return void
 	 */
 	public function testFailingDependency() {
@@ -68,6 +76,9 @@ class Requirements_Test extends TestCase {
 
 	/**
 	 * Tests that requirements are not met when a mix of valid and invalid dependencies are added.
+	 *
+	 * @covers Yoast_ACF_Analysis_Requirements::add_dependency
+	 * @covers Yoast_ACF_Analysis_Requirements::are_met
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _N/A_

## Relevant technical choices:

* Minimalist `@covers` tags to ensure that incidental code coverage will not be recorded.

At some point in the future, these _could_ be improved by having `@covers` tags at method level instead of at class level.

## Test instructions

This PR can be tested by following these steps:

* _N/A_
