### PR TITLE
CS: enforce consistent array format

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -105,6 +105,23 @@
 
 	<!--
 	#############################################################################
+	TEMPORARY TWEAK
+	YoastCS will demand short arrays, but until support for WP < 5.2 has been
+	dropped, this can - for now - only be allowed (and enforced) for the folders
+	containing PHP 5.6+ code.
+	#############################################################################
+	-->
+
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
+		<include-pattern>/tests/*</include-pattern>
+	</rule>
+
+
+	<!--
+	#############################################################################
 	TEMPORARY ADJUSTMENTS
 	Adjustments which should be removed once the associated issue has been resolved.
 	#############################################################################

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -255,7 +255,7 @@ class Configuration_Test extends TestCase {
 	 * @return void
 	 */
 	public function testScraperConfigFilter() {
-		$config    = array();
+		$config    = [];
 		$blacklist = new \Yoast_ACF_Analysis_String_Store();
 
 		$configuration = new \Yoast_ACF_Analysis_Configuration(
@@ -266,7 +266,7 @@ class Configuration_Test extends TestCase {
 
 		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'scraper_config' ) )
 			->once()
-			->with( array() )
+			->with( [] )
 			->andReturn( $config );
 
 		$this->assertSame( $config, $configuration->get_scraper_config() );
@@ -288,10 +288,10 @@ class Configuration_Test extends TestCase {
 
 		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'scraper_config' ) )
 			->once()
-			->with( array() )
+			->with( [] )
 			->andReturn( '' );
 
-		$this->assertSame( array(), $configuration->get_scraper_config() );
+		$this->assertSame( [], $configuration->get_scraper_config() );
 	}
 
 	/**

--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -65,6 +65,6 @@ class ACF_Dependency_Test extends TestCase {
 		$testee = new \Yoast_ACF_Analysis_Dependency_ACF();
 		$testee->register_notifications();
 
-		$this->assertTrue( has_action( 'admin_notices', array( $testee, 'message_plugin_not_activated' ) ) );
+		$this->assertTrue( has_action( 'admin_notices', [ $testee, 'message_plugin_not_activated' ] ) );
 	}
 }

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -90,7 +90,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$testee->register_notifications();
 
-		$this->assertTrue( has_action( 'admin_notices', array( $testee, 'message_plugin_not_activated' ) ) );
+		$this->assertTrue( has_action( 'admin_notices', [ $testee, 'message_plugin_not_activated' ] ) );
 	}
 
 	/**
@@ -104,6 +104,6 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$testee->register_notifications();
 
-		$this->assertTrue( has_action( 'admin_notices', array( $testee, 'message_minimum_version' ) ) );
+		$this->assertTrue( has_action( 'admin_notices', [ $testee, 'message_minimum_version' ] ) );
 	}
 }

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -58,14 +58,14 @@ class Assets_Test extends TestCase {
 			->once()
 			->with( AC_SEO_ACF_ANALYSIS_PLUGIN_FILE )
 			->andReturn(
-				array(
+				[
 					'Version' => '2.0.0',
-				)
+				]
 			);
 
 		$testee = new \Yoast_ACF_Analysis_Assets();
 		$testee->init();
 
-		$this->assertTrue( has_filter( 'admin_enqueue_scripts', array( $testee, 'enqueue_scripts' ) ) );
+		$this->assertTrue( has_filter( 'admin_enqueue_scripts', [ $testee, 'enqueue_scripts' ] ) );
 	}
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

WordPressCS will demand long arrays and forbid the use of short arrays as of WPCS 2.2.0.
See: https://make.wordpress.org/core/2019/07/12/php-coding-standards-changes/

For YoastCS, however, a choice has been made to demand short arrays.

For now, while WP 4.9, and therefore PHP 5.2 still needs to be supported, this is only possible in the directories containing files with PHP 5.6+ code.
So in this interim period, we will enforce short arrays in the PHP 5.6+ code and long arrays everywhere else.

Once the minimum supported WP version has moved up to WP 5.2 / PHP 5.6, short arrays will be enforced for all code and the change-over can be done automatically using the auto-fixer included in the relevant sniff.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.
