### PR TITLE
Stop explicit support for PHP < 5.6 / WP < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: trusty
-sudo: false
 
 cache:
   yarn: true
@@ -23,20 +22,17 @@ matrix:
   include:
     - php: 7.3
       env: PHPCS=1 CHECKJS=1 PHPUNIT=1 SECURITY=1 TRAVIS_NODE_VERSION=node
-    - php: 5.2
-      dist: precise
-    - php: 5.3
-      dist: precise
     - php: 5.6
       env: PHPUNIT=1
     - php: 7.0
       env: PHPUNIT=1
     - php: "7.4snapshot"
       env: PHPUNIT=1
+    - php: "nightly"
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
+    - php: "nightly"
 
 before_install:
 - export SECURITYCHECK_DIR=/tmp/security-checker
@@ -51,13 +47,11 @@ install:
 - if [[ "$SECURITY" == "1" ]]; then wget -P $SECURITYCHECK_DIR https://get.sensiolabs.org/security-checker.phar && chmod +x $SECURITYCHECK_DIR/security-checker.phar;fi
 
 script:
-# Exclude tests directory from linting for PHP 5.2/3
-- if [[ $TRAVIS_PHP_VERSION == "5.2" || $TRAVIS_PHP_VERSION == "5.3" ]]; then if find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -path ./tests -prune -o -name '*.php' -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
-- if [[ $TRAVIS_PHP_VERSION != "5.2" && $TRAVIS_PHP_VERSION != "5.3" ]]; then if find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi; fi
+- if find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi
 # Run PHPCS separately for the plugin files and the test files.
 - if [[ "$PHPCS" == "1" ]]; then composer check-cs; fi
 - if [[ "$CHECKJS" == "1" ]]; then grunt check; fi
 - if [[ "$PHPUNIT" == "1" ]]; then composer test; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
 # Check for known security vulnerabilities in the currently locked-in dependencies.
 - if [[ "$SECURITY" == "1" ]]; then php $SECURITYCHECK_DIR/security-checker.phar -n security:check $(pwd)/composer.lock;fi

--- a/composer.json
+++ b/composer.json
@@ -44,12 +44,10 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": ">=5.2",
-    "composer/installers": "~1.0",
-    "xrstf/composer-php52": "1.*"
+    "php": ">=5.6",
+    "composer/installers": "~1.0"
   },
   "require-dev": {
-    "php": ">=5.6.0",
     "brain/monkey": "2.*",
     "phpunit/phpunit": "^5.4 || ^6.0 || ^7.0",
     "yoast/yoastcs": "^1.3.0"
@@ -70,15 +68,6 @@
     }
   },
   "scripts": {
-    "post-install-cmd": [
-      "xrstf\\Composer52\\Generator::onPostInstallCmd"
-    ],
-    "post-update-cmd": [
-      "xrstf\\Composer52\\Generator::onPostInstallCmd"
-    ],
-    "post-autoload-dump": [
-      "xrstf\\Composer52\\Generator::onPostInstallCmd"
-    ],
     "test": [
       "@php ./vendor/phpunit/phpunit/phpunit --colors=always"
     ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e00024c578b89d2738c7dc82b97d1cf0",
+    "content-hash": "5f578e911b5440b454bf4cfa5b1ebb0f",
     "packages": [
         {
             "name": "composer/installers",
@@ -125,37 +125,6 @@
                 "zikula"
             ],
             "time": "2018-08-27T06:10:37+00:00"
-        },
-        {
-            "name": "xrstf/composer-php52",
-            "version": "v1.0.20",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer-php52/composer-php52.git",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer-php52/composer-php52/zipball/bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-default": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "xrstf\\Composer52": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "time": "2016-04-16T21:52:24+00:00"
         }
     ],
     "packages-dev": [
@@ -2134,11 +2103,9 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.2"
+        "php": ">=5.6"
     },
-    "platform-dev": {
-        "php": ">=5.6.0"
-    },
+    "platform-dev": [],
     "platform-overrides": {
         "php": "5.6.40"
     }

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === ACF Content Analysis for Yoast SEO ===
 Contributors: yoast, angrycreative, kraftner, marcusforsberg, viktorfroberg, joostdevalk, atimmer, jipmoors, theorboman
 Tags: Yoast, SEO, ACF, Advanced Custom Fields, analysis, Search Engine Optimization
-Requires at least: 4.9
-Tested up to: 5.2
+Requires at least: 5.2
+Tested up to: 5.3
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Stable tag: 2.3.0
-Requires PHP: 5.2.4
+Requires PHP: 5.6.20
 
 WordPress plugin that adds the content of all ACF fields to the Yoast SEO score analysis.
 

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -30,10 +30,6 @@ if ( ! defined( 'AC_SEO_ACF_ANALYSIS_PLUGIN_PATH' ) ) {
 
 $yoast_acf_autoload_file = '/vendor/autoload.php';
 
-if ( version_compare( PHP_VERSION, '5.3.2', '<' ) ) {
-	$yoast_acf_autoload_file = '/vendor/autoload_52.php';
-}
-
 if ( is_file( AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . $yoast_acf_autoload_file ) ) {
 	require AC_SEO_ACF_ANALYSIS_PLUGIN_PATH . $yoast_acf_autoload_file;
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Includes:
* Adjusting the `Requires...` info in the `readme.txt` file.
* Removing builds against PHP < 5.6.
* Removing the build against PHP 7.4 from allowed failures.
* Adding (back) a build against PHP `nightly` (PHP 8).
    For now, this build will only lint the code. Unit testing is not yet possible with the current setup.
* Removing the `xrstf/composer-php52` dependency and references to the `vendor/autoload_52.php` file.

As the YoastSEO ACF unit tests are already passing without problem on PHP 7.4, these changes can already be made and made in one go.

Also:
* Travis hasn't supported `sudo` for quite a while now, so removing it.

Related to https://github.com/Yoast/wordpress-seo/issues/13758


## Test instructions

This PR can be tested by following these steps:
* Check the detailed output of the Travis scripts to verify that all is working as expected.
