### PR TITLE
PHPCS: Update to YoastCS 2.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -103,23 +103,6 @@
 
 	<!--
 	#############################################################################
-	TEMPORARY TWEAK
-	YoastCS will demand short arrays, but until support for WP < 5.2 has been
-	dropped, this can - for now - only be allowed (and enforced) for the folders
-	containing PHP 5.6+ code.
-	#############################################################################
-	-->
-
-	<rule ref="Generic.Arrays.DisallowShortArraySyntax">
-		<exclude-pattern>/tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Generic.Arrays.DisallowLongArraySyntax">
-		<include-pattern>/tests/*</include-pattern>
-	</rule>
-
-
-	<!--
-	#############################################################################
 	SELECTIVE EXCLUSIONS
 	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
 	#############################################################################

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -36,7 +36,15 @@
 	#############################################################################
 	-->
 
-	<rule ref="Yoast"/>
+	<rule ref="Yoast">
+		<properties>
+			<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\ACF"/>
+				<element value="yoast_acf"/>
+			</property>
+		</properties>
+	</rule>
 
 
 	<!--
@@ -57,38 +65,28 @@
 	<rule ref="Yoast.Files.FileName">
 		<properties>
 			<!-- Don't trigger on the main file as renaming it would deactivate the plugin. -->
-			<property name="exclude" type="array">
+			<property name="excluded_files_strict_check" type="array">
 				<element value="yoast-acf-analysis.php"/>
 			</property>
 
 			<!-- Remove the following prefixes from the names of object structures. -->
-			<property name="prefixes" type="array">
+			<property name="oo_prefixes" type="array">
 				<element value="Yoast_ACF_Analysis"/>
 				<element value="yoast_acf"/>
 			</property>
 		</properties>
 	</rule>
 
-	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
-			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array">
-				<!-- Temporarily allowed until the prefixes are fixed. -->
-				<element value="AC_Yoast"/>
-				<element value="AC_SEO"/>
-				<element value="ysacf"/>
-				<!-- These are the new prefixes which all code should comply with in the future. -->
-				<element value="yoast_acf"/>
-				<element value="Yoast\WP\ACF"/>
+			<!-- Treat the "tests/php/unit" directory as a project root for path to namespace translations. -->
+			<property name="src_directory" type="array">
+				<element value="tests/php/unit"/>
 			</property>
-		</properties>
-	</rule>
 
-	<!-- Allow additional word delimiters for hook names. -->
-	<rule ref="WordPress.NamingConventions.ValidHookName">
-		<properties>
-			<property name="additionalWordDelimiters" value="/"/>
+			<property name="prefixes" type="array" extend="true">
+				<element value="Yoast\WP\ACF\Tests"/>
+			</property>
 		</properties>
 	</rule>
 
@@ -122,10 +120,35 @@
 
 	<!--
 	#############################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+	#############################################################################
+	-->
+
+	<!-- Valid usage: For testing purposes, some non-prefixed globals are being created. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<exclude-pattern>/integration-tests/bootstrap\.php$</exclude-pattern>
+		<exclude-pattern>/tests/bootstrap\.php$</exclude-pattern>
+	</rule>
+
+
+	<!--
+	#############################################################################
 	TEMPORARY ADJUSTMENTS
 	Adjustments which should be removed once the associated issue has been resolved.
 	#############################################################################
 	-->
+
+	<!-- Until all prefixes are fixed, some exceptions are allowed to the PrefixAllGlobals sniff. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" extend="true">
+				<element value="AC_Yoast"/>
+				<element value="AC_SEO"/>
+				<element value="ysacf"/>
+			</property>
+		</properties>
+	</rule>
 
 	<!-- Namespaced test classes imported via a use statement are not yet correctly excluded
 		 by WPCS. This will most likely be fixed once PHPCS 3.5.0 has been released and

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -145,7 +145,6 @@
 			<property name="prefixes" type="array" extend="true">
 				<element value="AC_Yoast"/>
 				<element value="AC_SEO"/>
-				<element value="ysacf"/>
 			</property>
 		</properties>
 	</rule>

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
   "require-dev": {
     "brain/monkey": "^2.4.0",
     "phpunit/phpunit": "^5.4 || ^6.0 || ^7.0",
-    "yoast/yoastcs": "^1.3.0"
+    "yoast/yoastcs": "^2.0.0"
   },
   "autoload": {
     "classmap": [ "inc" ]
@@ -79,8 +79,7 @@
       "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
     ],
     "check-cs": [
-      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --ignore=./tests",
-      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ./tests/ --runtime-set testVersion 5.6-"
+      "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
     ],
     "check-cs-errors": [
       "@check-cs"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49b8dba58b4cce4594342f5144bfccb7",
+    "content-hash": "859bfea9cc7fed22870f7f975790c77b",
     "packages": [
         {
             "name": "composer/installers",
@@ -519,16 +519,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.2",
+            "version": "9.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "bfca2be3992f40e92206e5a7ebe5eaee37280b58"
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/bfca2be3992f40e92206e5a7ebe5eaee37280b58",
-                "reference": "bfca2be3992f40e92206e5a7ebe5eaee37280b58",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1f37659196e4f3113ea506a7efba201c52303bf1",
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1",
                 "shasum": ""
             },
             "require": {
@@ -573,20 +573,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-10-16T21:24:24+00:00"
+            "time": "2019-11-15T04:12:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "94b2388c4fe99e9e2ef0772e280fa0eafa1d0603"
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/94b2388c4fe99e9e2ef0772e280fa0eafa1d0603",
-                "reference": "94b2388c4fe99e9e2ef0772e280fa0eafa1d0603",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
                 "shasum": ""
             },
             "require": {
@@ -625,7 +625,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-10-16T21:41:26+00:00"
+            "time": "2019-11-04T15:17:54+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -1792,16 +1792,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.1",
+            "version": "3.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "82cd0f854ceca17731d6d019c7098e3755c45060"
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/82cd0f854ceca17731d6d019c7098e3755c45060",
-                "reference": "82cd0f854ceca17731d6d019c7098e3755c45060",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
+                "reference": "557a1fc7ac702c66b0bbfe16ab3d55839ef724cb",
                 "shasum": ""
             },
             "require": {
@@ -1839,7 +1839,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-10-16T21:14:26+00:00"
+            "time": "2019-12-04T04:46:47+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2011,16 +2011,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.1.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908"
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bd9c33152115e6741e3510ff7189605b35167908",
-                "reference": "bd9c33152115e6741e3510ff7189605b35167908",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f90e8692ce97b693633db7ab20bfa78d930f536a",
+                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a",
                 "shasum": ""
             },
             "require": {
@@ -2043,7 +2043,7 @@
             "authors": [
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/graphs/contributors"
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
@@ -2052,30 +2052,32 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-05-21T02:50:00+00:00"
+            "time": "2019-11-11T12:34:03+00:00"
         },
         {
             "name": "yoast/yoastcs",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca"
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "php": ">=5.4",
-                "phpcompatibility/phpcompatibility-wp": "^2.0.0",
-                "squizlabs/php_codesniffer": "^3.4.2",
-                "wp-coding-standards/wpcs": "^2.1.1"
+                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+                "squizlabs/php_codesniffer": "^3.5.0",
+                "wp-coding-standards/wpcs": "^2.2.0"
             },
             "require-dev": {
+                "jakub-onderka/php-console-highlighter": "^0.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
                 "phpcompatibility/php-compatibility": "^9.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "roave/security-advisories": "dev-master"
@@ -2100,7 +2102,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2019-07-31T12:06:40+00:00"
+            "time": "2019-12-17T07:40:59+00:00"
         }
     ],
     "aliases": [],

--- a/inc/ac-yoast-seo-acf-content-analysis.php
+++ b/inc/ac-yoast-seo-acf-content-analysis.php
@@ -18,7 +18,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 	 * @return void
 	 */
 	public function init() {
-		add_action( 'admin_init', array( $this, 'admin_init' ) );
+		add_action( 'admin_init', [ $this, 'admin_init' ] );
 	}
 
 	/**
@@ -78,7 +78,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 		 */
 		$custom_configuration = apply_filters_deprecated(
 			'yoast-acf-analysis/config',
-			array( $configuration ),
+			[ $configuration ],
 			'YoastSEO ACF 2.4.0',
 			'Yoast\WP\ACF\config'
 		);
@@ -112,7 +112,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 	protected function register_config_filters() {
 		add_filter(
 			'Yoast\WP\ACF\scraper_config',
-			array( $this, 'filter_scraper_config' )
+			[ $this, 'filter_scraper_config' ]
 		);
 	}
 
@@ -137,7 +137,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 		 */
 		$headline = apply_filters_deprecated(
 			'yoast-acf-analysis/headlines',
-			array( array() ),
+			[ [] ],
 			'YoastSEO ACF 2.4.0',
 			'Yoast\WP\ACF\headlines'
 		);
@@ -163,9 +163,9 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 		 */
 		$headline = apply_filters( 'Yoast\WP\ACF\headlines', $headline );
 
-		$scraper_config['text'] = array(
+		$scraper_config['text'] = [
 			'headlines' => $headline,
-		);
+		];
 
 		return $scraper_config;
 	}
@@ -178,7 +178,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 	protected function get_field_selectors() {
 		$field_selectors = new Yoast_ACF_Analysis_String_Store();
 
-		$default_field_selectors = array(
+		$default_field_selectors = [
 			// Text.
 			'input[type=text][id^=acf]',
 
@@ -199,7 +199,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 
 			// Taxonomy.
 			'.acf-taxonomy-field',
-		);
+		];
 
 		foreach ( $default_field_selectors as $field_selector ) {
 			$field_selectors->add( $field_selector );
@@ -217,7 +217,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 
 		$blacklist = new Yoast_ACF_Analysis_String_Store();
 
-		$default_blacklist = array(
+		$default_blacklist = [
 			'number',
 			'password',
 
@@ -241,7 +241,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 			'repeater',
 			'flexible_content',
 			'group',
-		);
+		];
 
 		foreach ( $default_blacklist as $type ) {
 			$blacklist->add( $type );

--- a/inc/ac-yoast-seo-acf-content-analysis.php
+++ b/inc/ac-yoast-seo-acf-content-analysis.php
@@ -111,7 +111,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 	 */
 	protected function register_config_filters() {
 		add_filter(
-			'yoast-acf-analysis/scraper_config',
+			'Yoast\WP\ACF\scraper_config',
 			array( $this, 'filter_scraper_config' )
 		);
 	}

--- a/inc/ac-yoast-seo-acf-content-analysis.php
+++ b/inc/ac-yoast-seo-acf-content-analysis.php
@@ -75,7 +75,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 		 *
 		 * @param Yoast_ACF_Analysis_Configuration $configuration Plugin configuration instance
 		 */
-		$custom_configuration = apply_filters( Yoast_ACF_Analysis_Facade::get_filter_name( 'config' ), $configuration );
+		$custom_configuration = apply_filters( 'yoast-acf-analysis/config', $configuration );
 		if ( $custom_configuration instanceof Yoast_ACF_Analysis_Configuration ) {
 			$configuration = $custom_configuration;
 		}
@@ -90,7 +90,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 	 */
 	protected function register_config_filters() {
 		add_filter(
-			Yoast_ACF_Analysis_Facade::get_filter_name( 'scraper_config' ),
+			'yoast-acf-analysis/scraper_config',
 			array( $this, 'filter_scraper_config' )
 		);
 	}
@@ -123,7 +123,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 			 *      @type int    $headline_level Headline level 1 to 6
 			 * }
 			 */
-			'headlines' => apply_filters( Yoast_ACF_Analysis_Facade::get_filter_name( 'headlines' ), array() ),
+			'headlines' => apply_filters( 'yoast-acf-analysis/headlines', array() ),
 		);
 
 		return $scraper_config;

--- a/inc/ac-yoast-seo-acf-content-analysis.php
+++ b/inc/ac-yoast-seo-acf-content-analysis.php
@@ -53,7 +53,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 
 		$configuration = $registry->get( 'config' );
 
-		if ( null !== $configuration && $configuration instanceof Yoast_ACF_Analysis_Configuration ) {
+		if ( $configuration !== null && $configuration instanceof Yoast_ACF_Analysis_Configuration ) {
 			return;
 		}
 

--- a/inc/ac-yoast-seo-acf-content-analysis.php
+++ b/inc/ac-yoast-seo-acf-content-analysis.php
@@ -71,11 +71,32 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 		 *
 		 * @see Yoast_ACF_Analysis_Configuration
 		 *
-		 * @since 2.0.0
+		 * @since      2.0.0
+		 * @deprecated 2.4.0. Use the {@see 'Yoast\WP\ACF\config'} filter instead.
 		 *
 		 * @param Yoast_ACF_Analysis_Configuration $configuration Plugin configuration instance
 		 */
-		$custom_configuration = apply_filters( 'yoast-acf-analysis/config', $configuration );
+		$custom_configuration = apply_filters_deprecated(
+			'yoast-acf-analysis/config',
+			array( $configuration ),
+			'YoastSEO ACF 2.4.0',
+			'Yoast\WP\ACF\config'
+		);
+
+		/**
+		 * Filters the plugin configuration instance.
+		 *
+		 * You can replace the whole plugin configuration with a custom instance.
+		 * Only use this as a last resort as there are multiple more specific filters in the default configuration.
+		 *
+		 * @see Yoast_ACF_Analysis_Configuration
+		 *
+		 * @since 2.4.0
+		 *
+		 * @param Yoast_ACF_Analysis_Configuration $configuration Plugin configuration instance
+		 */
+		$custom_configuration = apply_filters( 'Yoast\WP\ACF\config', $custom_configuration );
+
 		if ( $custom_configuration instanceof Yoast_ACF_Analysis_Configuration ) {
 			$configuration = $custom_configuration;
 		}

--- a/inc/ac-yoast-seo-acf-content-analysis.php
+++ b/inc/ac-yoast-seo-acf-content-analysis.php
@@ -124,27 +124,47 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 	 * @return array The enhanched scraper config.
 	 */
 	public function filter_scraper_config( $scraper_config ) {
+		/**
+		 * Filters which ACF text fields are to be treated as a headline by the text scraper.
+		 *
+		 * @since      2.0.0
+		 * @deprecated 2.4.0. Use the {@see 'Yoast\WP\ACF\headlines'} filter instead.
+		 *
+		 * @param array $headlines_config {
+		 *      @type string $field_name     Name of the ACF field
+		 *      @type int    $headline_level Headline level 1 to 6
+		 * }
+		 */
+		$headline = apply_filters_deprecated(
+			'yoast-acf-analysis/headlines',
+			array( array() ),
+			'YoastSEO ACF 2.4.0',
+			'Yoast\WP\ACF\headlines'
+		);
+
+		/**
+		 * Filters which ACF text fields are to be treated as a headline by the text scraper.
+		 *
+		 * The array has the ACF field key as the array key and the value should be an integer from 1 to 6
+		 * that corresponds to the 6 possible HTML tags <h1> to <h6>.
+		 *
+		 * So this is how to make the field with the key "field_591eb45f2be86" a <h3>:
+		 *
+		 *     $headlines_config = array(
+		 *          'field_591eb45f2be86' => 3
+		 *     );
+		 *
+		 * @since 2.4.0
+		 *
+		 * @param array $headlines_config {
+		 *      @type string $field_name     Name of the ACF field
+		 *      @type int    $headline_level Headline level 1 to 6
+		 * }
+		 */
+		$headline = apply_filters( 'Yoast\WP\ACF\headlines', $headline );
+
 		$scraper_config['text'] = array(
-			/**
-			 * Filters which ACF text fields are to be treated as a headline by the text scraper.
-			 *
-			 * The array has the ACF field key as the array key and the value should be an integer from 1 to 6
-			 * that corresponds to the 6 possible HTML tags <h1> to <h6>.
-			 *
-			 * So this is how to make the field with the key "field_591eb45f2be86" a <h3>:
-			 *
-			 *     $headlines_config = array(
-			 *          'field_591eb45f2be86' => 3
-			 *     );
-			 *
-			 * @since 2.0.0
-			 *
-			 * @param array $headlines_config {
-			 *      @type string $field_name     Name of the ACF field
-			 *      @type int    $headline_level Headline level 1 to 6
-			 * }
-			 */
-			'headlines' => apply_filters( 'yoast-acf-analysis/headlines', array() ),
+			'headlines' => $headline,
 		);
 
 		return $scraper_config;

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -23,7 +23,7 @@ class Yoast_ACF_Analysis_Assets {
 	public function init() {
 		$this->plugin_data = get_plugin_data( AC_SEO_ACF_ANALYSIS_PLUGIN_FILE );
 
-		add_filter( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 11 );
+		add_filter( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ], 11 );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class Yoast_ACF_Analysis_Assets {
 			wp_enqueue_script(
 				'yoast-acf-analysis-post',
 				plugins_url( '/js/yoast-acf-analysis.js', AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ),
-				array( 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper', 'underscore' ),
+				[ 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper', 'underscore' ],
 				$this->plugin_data['Version'],
 				true
 			);
@@ -57,7 +57,7 @@ class Yoast_ACF_Analysis_Assets {
 			wp_enqueue_script(
 				'yoast-acf-analysis-term',
 				plugins_url( '/js/yoast-acf-analysis.js', AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ),
-				array( 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper' ),
+				[ 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper' ],
 				$this->plugin_data['Version'],
 				true
 			);

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -74,7 +74,7 @@ class Yoast_ACF_Analysis_Configuration {
 		}
 
 		// Fall back on filter use.
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- ACF hook.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- ACF hook.
 		return apply_filters( 'acf/get_info', 'version' );
 	}
 

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -175,7 +175,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 * Filters the scraper configuration.
 		 *
 		 * This nested array holds configuration specific to certain scrapers (for specific field types)
-		 * Before using this filter see if there isn't a more specific one like {@see yoast-acf-analysis/headlines}.
+		 * Before using this filter see if there isn't a more specific one like {@see 'Yoast\WP\ACF\headlines'}.
 		 *
 		 * @since 2.0.0
 		 *

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -286,6 +286,21 @@ class Yoast_ACF_Analysis_Configuration {
 		/**
 		 * Filters the CSS selectors that are used to find the fields when using ACF4.
 		 *
+		 * @since      2.0.0
+		 * @deprecated 2.4.0 Use the {@see 'Yoast\WP\ACF\field_selectors'} filter instead.
+		 *
+		 * @param Yoast_ACF_Analysis_String_Store $field_selectors Field selector store instance
+		 */
+		$field_selectors = apply_filters_deprecated(
+			'yoast-acf-analysis/field_selectors',
+			array( $this->field_selectors ),
+			'YoastSEO ACF 2.4.0',
+			'Yoast\WP\ACF\field_selectors'
+		);
+
+		/**
+		 * Filters the CSS selectors that are used to find the fields when using ACF4.
+		 *
 		 * This is an advanced filter that should rarely if ever be used, especially because it only affects ACF4.
 		 * If you want to exclude certain fields by type or name there are the more specific filters
 		 * {@see 'Yoast\WP\ACF\blacklist_type'} and {@see 'Yoast\WP\ACF\blacklist_name'} for these.
@@ -293,13 +308,13 @@ class Yoast_ACF_Analysis_Configuration {
 		 * @see get_blacklist_type()
 		 * @see get_blacklist_name()
 		 *
-		 * @since 2.0.0
+		 * @since 2.4.0
 		 *
 		 * @param Yoast_ACF_Analysis_String_Store $field_selectors Field selector store instance
 		 */
 		$field_selectors = apply_filters(
-			'yoast-acf-analysis/field_selectors',
-			$this->field_selectors
+			'Yoast\WP\ACF\field_selectors',
+			$field_selectors
 		);
 
 		if ( $field_selectors instanceof Yoast_ACF_Analysis_String_Store ) {

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -88,16 +88,31 @@ class Yoast_ACF_Analysis_Configuration {
 		/**
 		 * Filters the fields to ignore based on field type.
 		 *
+		 * @since      2.0.0
+		 * @deprecated 2.4.0. Use the {@see 'Yoast\WP\ACF\blacklist_type'} filter instead.
+		 *
+		 * @param Yoast_ACF_Analysis_String_Store $blacklist_type Store instance of ignored field types
+		 */
+		$blacklist_type = apply_filters_deprecated(
+			'yoast-acf-analysis/blacklist_type',
+			array( $this->blacklist_type ),
+			'YoastSEO ACF 2.4.0',
+			'Yoast\WP\ACF\blacklist_type'
+		);
+
+		/**
+		 * Filters the fields to ignore based on field type.
+		 *
 		 * You can add or remove field types to be analysed.
 		 * Be aware that when adding types this will only have an effect if there is a scraper for the type.
 		 *
-		 * @since 2.0.0
+		 * @since 2.4.0
 		 *
 		 * @param Yoast_ACF_Analysis_String_Store $blacklist_type Store instance of ignored field types
 		 */
 		$blacklist_type = apply_filters(
-			'yoast-acf-analysis/blacklist_type',
-			$this->blacklist_type
+			'Yoast\WP\ACF\blacklist_type',
+			$blacklist_type
 		);
 
 		if ( $blacklist_type instanceof Yoast_ACF_Analysis_String_Store ) {
@@ -228,7 +243,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 *
 		 * This is an advanced filter that should rarely if ever be used, especially because it only affects ACF4.
 		 * If you want to exclude certain fields by type or name there are the more specific filters
-		 * {@see 'yoast-acf-analysis/blacklist_type'} and {@see 'yoast-acf-analysis/blacklist_name'} for these.
+		 * {@see 'Yoast\WP\ACF\blacklist_type'} and {@see 'yoast-acf-analysis/blacklist_name'} for these.
 		 *
 		 * @see get_blacklist_type()
 		 * @see get_blacklist_name()

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -247,15 +247,30 @@ class Yoast_ACF_Analysis_Configuration {
 		/**
 		 * Refresh rate for changes to ACF fields
 		 *
+		 * @since      2.0.0
+		 * @deprecated 2.4.0 Use the {@see 'Yoast\WP\ACF\refresh_rate'} filter instead.
+		 *
+		 * @param int $refresh_rate Refresh rates in milliseconds
+		 */
+		$refresh_rate = apply_filters_deprecated(
+			'yoast-acf-analysis/refresh_rate',
+			array( $this->refresh_rate ),
+			'YoastSEO ACF 2.4.0',
+			'Yoast\WP\ACF\refresh_rate'
+		);
+
+		/**
+		 * Refresh rate for changes to ACF fields
+		 *
 		 * This plugin limits the rate at which changes to ACF fields are reported to Yoast SEO.
 		 * By default it will only report changes to Yoast SEO after no changes have happened for 1000 milliseconds.
 		 * This filter allows to change this to any value above 200 milliseconds.
 		 *
-		 * @since 2.0.0
+		 * @since 2.4.0
 		 *
 		 * @param int $refresh_rate Refresh rates in milliseconds
 		 */
-		$refresh_rate = apply_filters( 'yoast-acf-analysis/refresh_rate', $this->refresh_rate );
+		$refresh_rate = apply_filters( 'Yoast\WP\ACF\refresh_rate', $refresh_rate );
 		$refresh_rate = intval( $refresh_rate, 10 );
 
 		// Make sure the refresh rate is not too low, this will introduce problems in the browser of the user.

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -96,7 +96,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 * @param Yoast_ACF_Analysis_String_Store $blacklist_type Store instance of ignored field types
 		 */
 		$blacklist_type = apply_filters(
-			Yoast_ACF_Analysis_Facade::get_filter_name( 'blacklist_type' ),
+			'yoast-acf-analysis/blacklist_type',
 			$this->blacklist_type
 		);
 
@@ -145,7 +145,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 * @param Yoast_ACF_Analysis_String_Store $blacklist_name Store instance of ignored field names
 		 */
 		$blacklist_name = apply_filters(
-			Yoast_ACF_Analysis_Facade::get_filter_name( 'blacklist_name' ),
+			'yoast-acf-analysis/blacklist_name',
 			$this->blacklist_name
 		);
 
@@ -182,7 +182,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 * @param array $scraper_config Nested array of scraper configuration
 		 */
 		$scraper_config = apply_filters(
-			Yoast_ACF_Analysis_Facade::get_filter_name( 'scraper_config' ),
+			'yoast-acf-analysis/scraper_config',
 			$this->scraper_config
 		);
 
@@ -210,7 +210,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 *
 		 * @param int $refresh_rate Refresh rates in milliseconds
 		 */
-		$refresh_rate = apply_filters( Yoast_ACF_Analysis_Facade::get_filter_name( 'refresh_rate' ), $this->refresh_rate );
+		$refresh_rate = apply_filters( 'yoast-acf-analysis/refresh_rate', $this->refresh_rate );
 		$refresh_rate = intval( $refresh_rate, 10 );
 
 		// Make sure the refresh rate is not too low, this will introduce problems in the browser of the user.
@@ -238,7 +238,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 * @param Yoast_ACF_Analysis_String_Store $field_selectors Field selector store instance
 		 */
 		$field_selectors = apply_filters(
-			Yoast_ACF_Analysis_Facade::get_filter_name( 'field_selectors' ),
+			'yoast-acf-analysis/field_selectors',
 			$this->field_selectors
 		);
 
@@ -274,7 +274,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 *      @type int    $order          Integer
 		 * }
 		 */
-		return apply_filters( Yoast_ACF_Analysis_Facade::get_filter_name( 'field_order' ), array() );
+		return apply_filters( 'yoast-acf-analysis/field_order', array() );
 	}
 
 	/**

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -43,7 +43,7 @@ class Yoast_ACF_Analysis_Configuration {
 	 *
 	 * @var array
 	 */
-	protected $scraper_config = array();
+	protected $scraper_config = [];
 
 	/**
 	 * Yoast_ACF_Analysis_Configuration constructor.
@@ -95,7 +95,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$blacklist_type = apply_filters_deprecated(
 			'yoast-acf-analysis/blacklist_type',
-			array( $this->blacklist_type ),
+			[ $this->blacklist_type ],
 			'YoastSEO ACF 2.4.0',
 			'Yoast\WP\ACF\blacklist_type'
 		);
@@ -139,7 +139,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$legacy_names = apply_filters_deprecated(
 			'ysacf_exclude_fields',
-			array( array() ),
+			[ [] ],
 			'YoastSEO ACF 2.0.0',
 			'Yoast\WP\ACF\blacklist_name'
 		);
@@ -160,7 +160,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$blacklist_name = apply_filters_deprecated(
 			'yoast-acf-analysis/blacklist_name',
-			array( $this->blacklist_name ),
+			[ $this->blacklist_name ],
 			'YoastSEO ACF 2.4.0',
 			'Yoast\WP\ACF\blacklist_name'
 		);
@@ -211,7 +211,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$scraper_config = apply_filters_deprecated(
 			'yoast-acf-analysis/scraper_config',
-			array( $this->scraper_config ),
+			[ $this->scraper_config ],
 			'YoastSEO ACF 2.4.0',
 			'Yoast\WP\ACF\scraper_config'
 		);
@@ -235,7 +235,7 @@ class Yoast_ACF_Analysis_Configuration {
 			return $scraper_config;
 		}
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -254,7 +254,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$refresh_rate = apply_filters_deprecated(
 			'yoast-acf-analysis/refresh_rate',
-			array( $this->refresh_rate ),
+			[ $this->refresh_rate ],
 			'YoastSEO ACF 2.4.0',
 			'Yoast\WP\ACF\refresh_rate'
 		);
@@ -293,7 +293,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$field_selectors = apply_filters_deprecated(
 			'yoast-acf-analysis/field_selectors',
-			array( $this->field_selectors ),
+			[ $this->field_selectors ],
 			'YoastSEO ACF 2.4.0',
 			'Yoast\WP\ACF\field_selectors'
 		);
@@ -343,7 +343,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$field_order = apply_filters_deprecated(
 			'yoast-acf-analysis/field_order',
-			array( array() ),
+			[ [] ],
 			'YoastSEO ACF 2.4.0',
 			'Yoast\WP\ACF\field_order'
 		);
@@ -376,7 +376,7 @@ class Yoast_ACF_Analysis_Configuration {
 	 * @return array
 	 */
 	public function to_array() {
-		return array(
+		return [
 			'pluginName'     => Yoast_ACF_Analysis_Facade::get_plugin_name(),
 			'acfVersion'     => $this->get_acf_version(),
 			'scraper'        => $this->get_scraper_config(),
@@ -386,6 +386,6 @@ class Yoast_ACF_Analysis_Configuration {
 			'fieldSelectors' => $this->get_field_selectors()->to_array(),
 			'fieldOrder'     => $this->get_field_order(),
 			'debug'          => $this->is_debug(),
-		);
+		];
 	}
 }

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -204,16 +204,31 @@ class Yoast_ACF_Analysis_Configuration {
 		/**
 		 * Filters the scraper configuration.
 		 *
+		 * @since      2.0.0
+		 * @deprecated 2.4.0 Use the {@see 'Yoast\WP\ACF\scraper_config'} filter instead.
+		 *
+		 * @param array $scraper_config Nested array of scraper configuration
+		 */
+		$scraper_config = apply_filters_deprecated(
+			'yoast-acf-analysis/scraper_config',
+			array( $this->scraper_config ),
+			'YoastSEO ACF 2.4.0',
+			'Yoast\WP\ACF\scraper_config'
+		);
+
+		/**
+		 * Filters the scraper configuration.
+		 *
 		 * This nested array holds configuration specific to certain scrapers (for specific field types)
 		 * Before using this filter see if there isn't a more specific one like {@see 'Yoast\WP\ACF\headlines'}.
 		 *
-		 * @since 2.0.0
+		 * @since 2.4.0
 		 *
 		 * @param array $scraper_config Nested array of scraper configuration
 		 */
 		$scraper_config = apply_filters(
-			'yoast-acf-analysis/scraper_config',
-			$this->scraper_config
+			'Yoast\WP\ACF\scraper_config',
+			$scraper_config
 		);
 
 		if ( is_array( $scraper_config ) ) {

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -132,16 +132,16 @@ class Yoast_ACF_Analysis_Configuration {
 		/**
 		 * Filters the fields to ignore based on field name.
 		 *
-		 * You can add or remove fields to be analysed based on the field name.
-		 *
-		 * @since 1.0.0
-		 * @deprecated 2.0.0 Use the {@see 'yoast-acf-analysis/blacklist_name'} filter instead.
+		 * @since      1.0.0
+		 * @deprecated 2.0.0 Use the {@see 'Yoast\WP\ACF\blacklist_name'} filter instead.
 		 *
 		 * @param array $legacy_names Array with field names
 		 */
-		$legacy_names = apply_filters(
+		$legacy_names = apply_filters_deprecated(
 			'ysacf_exclude_fields',
-			array()
+			array( array() ),
+			'YoastSEO ACF 2.0.0',
+			'Yoast\WP\ACF\blacklist_name'
 		);
 
 		if ( is_array( $legacy_names ) && ! empty( $legacy_names ) ) {
@@ -153,15 +153,30 @@ class Yoast_ACF_Analysis_Configuration {
 		/**
 		 * Filters the fields to ignore based on field name.
 		 *
+		 * @since      2.0.0
+		 * @deprecated 2.4.0 Use the {@see 'Yoast\WP\ACF\blacklist_name'} filter instead.
+		 *
+		 * @param Yoast_ACF_Analysis_String_Store $blacklist_name Store instance of ignored field names
+		 */
+		$blacklist_name = apply_filters_deprecated(
+			'yoast-acf-analysis/blacklist_name',
+			array( $this->blacklist_name ),
+			'YoastSEO ACF 2.4.0',
+			'Yoast\WP\ACF\blacklist_name'
+		);
+
+		/**
+		 * Filters the fields to ignore based on field name.
+		 *
 		 * You can add or remove fields to be analysed based on the field name.
 		 *
-		 * @since 2.0.0
+		 * @since 2.4.0
 		 *
 		 * @param Yoast_ACF_Analysis_String_Store $blacklist_name Store instance of ignored field names
 		 */
 		$blacklist_name = apply_filters(
-			'yoast-acf-analysis/blacklist_name',
-			$this->blacklist_name
+			'Yoast\WP\ACF\blacklist_name',
+			$blacklist_name
 		);
 
 		if ( $blacklist_name instanceof Yoast_ACF_Analysis_String_Store ) {
@@ -243,7 +258,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 *
 		 * This is an advanced filter that should rarely if ever be used, especially because it only affects ACF4.
 		 * If you want to exclude certain fields by type or name there are the more specific filters
-		 * {@see 'Yoast\WP\ACF\blacklist_type'} and {@see 'yoast-acf-analysis/blacklist_name'} for these.
+		 * {@see 'Yoast\WP\ACF\blacklist_type'} and {@see 'Yoast\WP\ACF\blacklist_name'} for these.
 		 *
 		 * @see get_blacklist_type()
 		 * @see get_blacklist_name()

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -333,6 +333,24 @@ class Yoast_ACF_Analysis_Configuration {
 		/**
 		 * Filters the order of the ACF fields relative to the post_content.
 		 *
+		 * @since      2.2.0
+		 * @deprecated 2.4.0 Use the {@see 'Yoast\WP\ACF\field_order'} filter instead.
+		 *
+		 * @param array $order_config {
+		 *      @type string $field_name     Name of the ACF field
+		 *      @type int    $order          Integer
+		 * }
+		 */
+		$field_order = apply_filters_deprecated(
+			'yoast-acf-analysis/field_order',
+			array( array() ),
+			'YoastSEO ACF 2.4.0',
+			'Yoast\WP\ACF\field_order'
+		);
+
+		/**
+		 * Filters the order of the ACF fields relative to the post_content.
+		 *
 		 * The array has the ACF field key as the array key and the value should be an integer
 		 * where negative values result in the field value being placed before the default post_content.
 		 *
@@ -342,14 +360,14 @@ class Yoast_ACF_Analysis_Configuration {
 		 *          'field_591eb45f2be86' => -1
 		 *     );
 		 *
-		 * @since 2.2.0
+		 * @since 2.4.0
 		 *
 		 * @param array $order_config {
 		 *      @type string $field_name     Name of the ACF field
 		 *      @type int    $order          Integer
 		 * }
 		 */
-		return apply_filters( 'yoast-acf-analysis/field_order', array() );
+		return apply_filters( 'Yoast\WP\ACF\field_order', $field_order );
 	}
 
 	/**

--- a/inc/configuration/string-store.php
+++ b/inc/configuration/string-store.php
@@ -17,7 +17,7 @@ class Yoast_ACF_Analysis_String_Store {
 	 *
 	 * @var array
 	 */
-	protected $items = array();
+	protected $items = [];
 
 	/**
 	 * Adds an item to the store.
@@ -55,7 +55,7 @@ class Yoast_ACF_Analysis_String_Store {
 			return false;
 		}
 
-		$items       = array_diff( $this->items, array( $item ) );
+		$items       = array_diff( $this->items, [ $item ] );
 		$this->items = array_values( $items );
 		sort( $this->items );
 

--- a/inc/dependencies/dependency-acf.php
+++ b/inc/dependencies/dependency-acf.php
@@ -27,7 +27,7 @@ final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Depe
 	 * Registers the notification to show when the conditions are not met.
 	 */
 	public function register_notifications() {
-		add_action( 'admin_notices', array( $this, 'message_plugin_not_activated' ) );
+		add_action( 'admin_notices', [ $this, 'message_plugin_not_activated' ] );
 	}
 
 	/**

--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -34,12 +34,12 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 	 */
 	public function register_notifications() {
 		if ( ! defined( 'WPSEO_VERSION' ) ) {
-			add_action( 'admin_notices', array( $this, 'message_plugin_not_activated' ) );
+			add_action( 'admin_notices', [ $this, 'message_plugin_not_activated' ] );
 			return;
 		}
 
 		if ( ! $this->has_required_version() ) {
-			add_action( 'admin_notices', array( $this, 'message_minimum_version' ) );
+			add_action( 'admin_notices', [ $this, 'message_minimum_version' ] );
 		}
 	}
 

--- a/inc/facade.php
+++ b/inc/facade.php
@@ -37,6 +37,9 @@ class Yoast_ACF_Analysis_Facade {
 	/**
 	 * Wraps the notification with an unique identifier.
 	 *
+	 * @deprecated 2.4.0 Use hard-coded filter names instead.
+	 * @codeCoverageIgnore
+	 *
 	 * @param string $filter_name Filter to wrap.
 	 *
 	 * @return string Full filter name to use.

--- a/inc/facade.php
+++ b/inc/facade.php
@@ -27,7 +27,7 @@ class Yoast_ACF_Analysis_Facade {
 	public static function get_registry() {
 		static $registry = null;
 
-		if ( null === $registry ) {
+		if ( $registry === null ) {
 			$registry = new Yoast_ACF_Analysis_Registry();
 		}
 

--- a/inc/registry.php
+++ b/inc/registry.php
@@ -15,7 +15,7 @@ class Yoast_ACF_Analysis_Registry {
 	 *
 	 * @var array
 	 */
-	private $storage = array();
+	private $storage = [];
 
 	/**
 	 * Adds an item to the registry.

--- a/inc/requirements.php
+++ b/inc/requirements.php
@@ -15,7 +15,7 @@ class Yoast_ACF_Analysis_Requirements {
 	 *
 	 * @var Yoast_ACF_Analysis_Dependency[]
 	 */
-	protected $dependencies = array();
+	protected $dependencies = [];
 
 	/**
 	 * Adds a dependency.

--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,7 @@ Previously called Yoast ACF Analysis.
 });`
 
 = Define custom field a specific heading value =
-`add_filter( 'yoast-acf-analysis/headlines', function ( $headlines ) {
+`add_filter( 'Yoast\WP\ACF\headlines', function ( $headlines ) {
     // value from 1-6, 1=h1, 6=h6
     $headlines['field_591eb45f2be86'] = 3;
     return $headlines;

--- a/readme.txt
+++ b/readme.txt
@@ -33,7 +33,7 @@ Previously called Yoast ACF Analysis.
 });`
 
 = Remove field type from scoring =
-`add_filter( 'yoast-acf-analysis/blacklist_type', function ( $blacklist_type ) {
+`add_filter( 'Yoast\WP\ACF\blacklist_type', function ( $blacklist_type ) {
     // text, image etc
     $blacklist_type->add( 'text' );
     $blacklist_type->add( 'image' );

--- a/readme.txt
+++ b/readme.txt
@@ -48,7 +48,7 @@ Previously called Yoast ACF Analysis.
 });`
 
 = Change refresh rate =
-`add_filter( 'yoast-acf-analysis/refresh_rate', function () {
+`add_filter( 'Yoast\WP\ACF\refresh_rate', function () {
     // Refresh rates in milliseconds
     return 1000;
 });`

--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,7 @@ Previously called Yoast ACF Analysis.
 == Filters ==
 
 = Remove specific field from scoring =
-`add_filter( 'yoast-acf-analysis/blacklist_name', function ( $blacklist_name ) {
+`add_filter( 'Yoast\WP\ACF\blacklist_name', function ( $blacklist_name ) {
     $blacklist_name->add( 'my-field-name' );
     return $blacklist_name;
 });`

--- a/tests/js/system/data/test-data-loader-functions.php
+++ b/tests/js/system/data/test-data-loader-functions.php
@@ -15,7 +15,7 @@ if ( function_exists( 'add_action' ) ) {
  */
 function yoast_acf_analysis_test_data_loader() {
 
-	if ( ! defined( 'AC_YOAST_ACF_ANALYSIS_ENVIRONMENT' ) || 'development' !== AC_YOAST_ACF_ANALYSIS_ENVIRONMENT ) {
+	if ( ! defined( 'AC_YOAST_ACF_ANALYSIS_ENVIRONMENT' ) || AC_YOAST_ACF_ANALYSIS_ENVIRONMENT !== 'development' ) {
 		return;
 	}
 

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -149,7 +149,7 @@ class Configuration_Test extends TestCase {
 
 		$blacklist_name2 = new \Yoast_ACF_Analysis_String_Store();
 
-		Filters\expectApplied( 'yoast-acf-analysis/blacklist_name' )
+		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_name' )
 			->once()
 			->with( $blacklist_name )
 			->andReturn( $blacklist_name2 );
@@ -241,7 +241,7 @@ class Configuration_Test extends TestCase {
 			new \Yoast_ACF_Analysis_String_Store()
 		);
 
-		Filters\expectApplied( 'yoast-acf-analysis/blacklist_name' )
+		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_name' )
 			->once()
 			->with( $store )
 			->andReturn( '' );

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -349,7 +349,7 @@ class Configuration_Test extends TestCase {
 			$field_selector
 		);
 
-		Filters\expectApplied( 'yoast-acf-analysis/field_selectors' )
+		Filters\expectApplied( 'Yoast\WP\ACF\field_selectors' )
 			->once()
 			->with( $field_selector )
 			->andReturn( $custom_store );
@@ -372,7 +372,7 @@ class Configuration_Test extends TestCase {
 			$store
 		);
 
-		Filters\expectApplied( 'yoast-acf-analysis/field_selectors' )
+		Filters\expectApplied( 'Yoast\WP\ACF\field_selectors' )
 			->once()
 			->with( $store )
 			->andReturn( '' );

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -300,7 +300,7 @@ class Configuration_Test extends TestCase {
 	 * @return void
 	 */
 	public function testRefreshRateFilter() {
-		Filters\expectApplied( 'yoast-acf-analysis/refresh_rate' )
+		Filters\expectApplied( 'Yoast\WP\ACF\refresh_rate' )
 			->once()
 			->with( 1000 )
 			->andReturn( 9999 );
@@ -320,7 +320,7 @@ class Configuration_Test extends TestCase {
 	 * @return void
 	 */
 	public function testRefreshRateMinimumValueFilter() {
-		Filters\expectApplied( 'yoast-acf-analysis/refresh_rate' )
+		Filters\expectApplied( 'Yoast\WP\ACF\refresh_rate' )
 			->once()
 			->with( 1000 )
 			->andReturn( 1 );

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -101,7 +101,7 @@ class Configuration_Test extends TestCase {
 
 		$blacklist_type2 = new \Yoast_ACF_Analysis_String_Store();
 
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'blacklist_type' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/blacklist_type' )
 			->once()
 			->with( $blacklist_type )
 			->andReturn( $blacklist_type2 );
@@ -124,7 +124,7 @@ class Configuration_Test extends TestCase {
 			new \Yoast_ACF_Analysis_String_Store()
 		);
 
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'blacklist_type' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/blacklist_type' )
 			->once()
 			->with( $store )
 			->andReturn( '' );
@@ -149,7 +149,7 @@ class Configuration_Test extends TestCase {
 
 		$blacklist_name2 = new \Yoast_ACF_Analysis_String_Store();
 
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'blacklist_name' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/blacklist_name' )
 			->once()
 			->with( $blacklist_name )
 			->andReturn( $blacklist_name2 );
@@ -241,7 +241,7 @@ class Configuration_Test extends TestCase {
 			new \Yoast_ACF_Analysis_String_Store()
 		);
 
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'blacklist_name' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/blacklist_name' )
 			->once()
 			->with( $store )
 			->andReturn( '' );
@@ -264,7 +264,7 @@ class Configuration_Test extends TestCase {
 			new \Yoast_ACF_Analysis_String_Store()
 		);
 
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'scraper_config' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/scraper_config' )
 			->once()
 			->with( [] )
 			->andReturn( $config );
@@ -286,7 +286,7 @@ class Configuration_Test extends TestCase {
 			new \Yoast_ACF_Analysis_String_Store()
 		);
 
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'scraper_config' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/scraper_config' )
 			->once()
 			->with( [] )
 			->andReturn( '' );
@@ -300,7 +300,7 @@ class Configuration_Test extends TestCase {
 	 * @return void
 	 */
 	public function testRefreshRateFilter() {
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'refresh_rate' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/refresh_rate' )
 			->once()
 			->with( 1000 )
 			->andReturn( 9999 );
@@ -320,7 +320,7 @@ class Configuration_Test extends TestCase {
 	 * @return void
 	 */
 	public function testRefreshRateMinimumValueFilter() {
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'refresh_rate' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/refresh_rate' )
 			->once()
 			->with( 1000 )
 			->andReturn( 1 );
@@ -349,7 +349,7 @@ class Configuration_Test extends TestCase {
 			$field_selector
 		);
 
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'field_selectors' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/field_selectors' )
 			->once()
 			->with( $field_selector )
 			->andReturn( $custom_store );
@@ -372,7 +372,7 @@ class Configuration_Test extends TestCase {
 			$store
 		);
 
-		Filters\expectApplied( \Yoast_ACF_Analysis_Facade::get_filter_name( 'field_selectors' ) )
+		Filters\expectApplied( 'yoast-acf-analysis/field_selectors' )
 			->once()
 			->with( $store )
 			->andReturn( '' );

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -101,7 +101,7 @@ class Configuration_Test extends TestCase {
 
 		$blacklist_type2 = new \Yoast_ACF_Analysis_String_Store();
 
-		Filters\expectApplied( 'yoast-acf-analysis/blacklist_type' )
+		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_type' )
 			->once()
 			->with( $blacklist_type )
 			->andReturn( $blacklist_type2 );
@@ -124,7 +124,7 @@ class Configuration_Test extends TestCase {
 			new \Yoast_ACF_Analysis_String_Store()
 		);
 
-		Filters\expectApplied( 'yoast-acf-analysis/blacklist_type' )
+		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_type' )
 			->once()
 			->with( $store )
 			->andReturn( '' );

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -264,7 +264,7 @@ class Configuration_Test extends TestCase {
 			new \Yoast_ACF_Analysis_String_Store()
 		);
 
-		Filters\expectApplied( 'yoast-acf-analysis/scraper_config' )
+		Filters\expectApplied( 'Yoast\WP\ACF\scraper_config' )
 			->once()
 			->with( [] )
 			->andReturn( $config );
@@ -286,7 +286,7 @@ class Configuration_Test extends TestCase {
 			new \Yoast_ACF_Analysis_String_Store()
 		);
 
-		Filters\expectApplied( 'yoast-acf-analysis/scraper_config' )
+		Filters\expectApplied( 'Yoast\WP\ACF\scraper_config' )
 			->once()
 			->with( [] )
 			->andReturn( '' );


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Deprecates `Yoast_ACF_Analysis_Facade::get_filter_name()`. Use hard-coded hook names instead.
* This deprecates the  `yoast-acf-analysis/config` filter hook in favour of the `Yoast\WP\ACF\config` hook.
* This deprecates the `yoast-acf-analysis/headlines` filter hook in favour of the `Yoast\WP\ACF\headlines` hook.
* This deprecates the `yoast-acf-analysis/blacklist_type` filter hook in favour of the `Yoast\WP\ACF\blacklist_type` hook.
* This deprecates the `yoast-acf-analysis/blacklist_name` filter hook in favour of the `Yoast\WP\ACF\blacklist_name` hook.
* This deprecates the `yoast-acf-analysis/scraper_config` filter hook in favour of the `Yoast\WP\ACF\scraper_config` hook.
* This deprecates the `yoast-acf-analysis/refresh_rate` filter hook in favour of the `Yoast\WP\ACF\refresh_rate` hook.
* This deprecates the `yoast-acf-analysis/field_selectors` filter hook in favour of the `Yoast\WP\ACF\field_selectors` hook.
* This deprecates the `yoast-acf-analysis/field_order` filter hook in favour of the `Yoast\WP\ACF\field_order` hook.

## Relevant technical choices:

:exclamation: This PR will be easiest to review by going through the commits individually.

### PHPCS: Update to YoastCS 2.0.0

This updates the dependency in `composer.json`, as well as the PHPCS ruleset for YoastCS 2.0.0.

Includes:
* A selective update of the `composer.lock` for just YoastCS and its dependencies.
* Removing the tweaks to the Composer `check-cs` script to allow for different PHP requirements in different directories.
    PHP 5.6 is now the minimum PHP version everywhere.

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0

### PHPCS: whitelist an acf hook used

### Deprecate `Yoast_ACF_Analysis_Facade::get_filter_name()`

Having filter names created via a function call makes it impossible for documentation scrapers to document the available filters.

This commit deprecated the method which was used for this and changes all existing filter to hard-coded filter names.

The filter names, however, are still the same, so this does not constitute a BC-break.

### CS: deprecate old-style hook and add new-style hook [1]

This deprecates the  `yoast-acf-analysis/config` filter hook in favour of the `Yoast\WP\ACF\config` hook.

[This needs a changelog entry]

### CS: deprecate old-style hook and add new-style hook [2]

This deprecates the `yoast-acf-analysis/headlines` filter hook in favour of the `Yoast\WP\ACF\headlines` hook.

[This needs a changelog entry]

### CS: deprecate old-style hook and add new-style hook [3]

This deprecates the `yoast-acf-analysis/blacklist_type` filter hook in favour of the `Yoast\WP\ACF\blacklist_type` hook.

[This needs a changelog entry]

### CS: deprecate old-style hook and add new-style hook [4]

This deprecates the `yoast-acf-analysis/blacklist_name` filter hook in favour of the `Yoast\WP\ACF\blacklist_name` hook.

Includes adjusting a previously deprecated filter which should now point to the new-style filter to use `apply_filters_deprecated()` and provide proper deprecation information.

[This needs a changelog entry]

### CS: deprecate old-style hook and add new-style hook [5]

This deprecates the `yoast-acf-analysis/scraper_config` filter hook in favour of the `Yoast\WP\ACF\scraper_config` hook.

[This needs a changelog entry]

### CS: deprecate old-style hook and add new-style hook [6]

This deprecates the `yoast-acf-analysis/refresh_rate` filter hook in favour of the `Yoast\WP\ACF\refresh_rate` hook.

[This needs a changelog entry]

### CS: deprecate old-style hook and add new-style hook [7]

This deprecates the `yoast-acf-analysis/field_selectors` filter hook in favour of the `Yoast\WP\ACF\field_selectors` hook.

[This needs a changelog entry]

### CS: deprecate old-style hook and add new-style hook [8]

This deprecates the `yoast-acf-analysis/field_order` filter hook in favour of the `Yoast\WP\ACF\field_order` hook.

[This needs a changelog entry]

### CS: use short arrays (everywhere)

### CS: don't use Yoda conditions 

## Test instructions

This PR can be tested by following these steps:

See the test instructions in the Yoast/wpseo-woocommerce#451 PR for guidance on how to test this PR. 

Closes #228
