### PR TITLE
Travis: use 7.4 not snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,11 @@ branches:
 matrix:
   fast_finish: true
   include:
-    - php: 7.3
+    - php: 7.4
       env: PHPCS=1 CHECKJS=1 PHPUNIT=1 SECURITY=1 TRAVIS_NODE_VERSION=node
     - php: 5.6
       env: PHPUNIT=1
     - php: 7.0
-      env: PHPUNIT=1
-    - php: "7.4snapshot"
       env: PHPUNIT=1
     - php: "nightly"
 
@@ -52,6 +50,6 @@ script:
 - if [[ "$PHPCS" == "1" ]]; then composer check-cs; fi
 - if [[ "$CHECKJS" == "1" ]]; then grunt check; fi
 - if [[ "$PHPUNIT" == "1" ]]; then composer test; fi
-- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
+- if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.4" ]]; then composer validate --no-check-all; fi
 # Check for known security vulnerabilities in the currently locked-in dependencies.
 - if [[ "$SECURITY" == "1" ]]; then php $SECURITYCHECK_DIR/security-checker.phar -n security:check $(pwd)/composer.lock;fi


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Since mid December, Travis now has a native PHP 7.4 image available.


## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.