### PR TITLE
QA: remove unused variable import

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -30,8 +30,6 @@ class Yoast_ACF_Analysis_Assets {
 	 * Enqueue JavaScript file to feed data to Yoast Content Analyses.
 	 */
 	public function enqueue_scripts() {
-		global $pagenow;
-
 		/**
 		 * Yoast ACF plugin configuration.
 		 *


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

`$pagenow` is not used in the function.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.