### PR TITLE
QA: don't use yoda conditions

### DIFF
--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -91,6 +91,6 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 	 * @return bool
 	 */
 	private function has_required_version() {
-		return -1 !== version_compare( $this->get_major_version( WPSEO_VERSION ), self::MINIMAL_REQUIRED_VERSION );
+		return version_compare( $this->get_major_version( WPSEO_VERSION ), self::MINIMAL_REQUIRED_VERSION, '>=' );
 	}
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

As `version_compare()` can return boolean when the third parameter is used, there is no need for the compare here anyway.




## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.