### PR TITLE
QA: add missing import `use` statements for classes

### DIFF
--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -6,6 +6,9 @@ use Brain\Monkey;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use Yoast_ACF_Analysis_Configuration;
+use Yoast_ACF_Analysis_String_Store;
+use Yoast_ACF_Analysis_Facade;
 
 /**
  * Class Configuration_Test.
@@ -41,15 +44,15 @@ class Configuration_Test extends TestCase {
 	 */
 	public function testEmpty() {
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store()
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
 		$this->assertSame(
 			[
-				'pluginName'     => \Yoast_ACF_Analysis_Facade::get_plugin_name(),
+				'pluginName'     => Yoast_ACF_Analysis_Facade::get_plugin_name(),
 				'acfVersion'     => 'version',
 				'scraper'        => [],
 				'refreshRate'    => 1000,
@@ -74,10 +77,10 @@ class Configuration_Test extends TestCase {
 		$acf_version = '5.0.0';
 		Functions\when( 'acf_get_setting' )->justReturn( $acf_version );
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store()
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store()
 		);
 		$config        = $configuration->to_array();
 
@@ -91,15 +94,15 @@ class Configuration_Test extends TestCase {
 	 */
 	public function testBlacklistTypeFilter() {
 
-		$blacklist_type = new \Yoast_ACF_Analysis_String_Store();
+		$blacklist_type = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
+		$configuration = new Yoast_ACF_Analysis_Configuration(
 			$blacklist_type,
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
-		$blacklist_type2 = new \Yoast_ACF_Analysis_String_Store();
+		$blacklist_type2 = new Yoast_ACF_Analysis_String_Store();
 
 		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_type' )
 			->once()
@@ -116,12 +119,12 @@ class Configuration_Test extends TestCase {
 	 */
 	public function testBlacklistTypeFilterInvalid() {
 
-		$store = new \Yoast_ACF_Analysis_String_Store();
+		$store = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
+		$configuration = new Yoast_ACF_Analysis_Configuration(
 			$store,
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_type' )
@@ -139,15 +142,15 @@ class Configuration_Test extends TestCase {
 	 */
 	public function testBlacklistNameFilter() {
 
-		$blacklist_name = new \Yoast_ACF_Analysis_String_Store();
+		$blacklist_name = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
 			$blacklist_name,
-			new \Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
-		$blacklist_name2 = new \Yoast_ACF_Analysis_String_Store();
+		$blacklist_name2 = new Yoast_ACF_Analysis_String_Store();
 
 		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_name' )
 			->once()
@@ -164,12 +167,12 @@ class Configuration_Test extends TestCase {
 	 */
 	public function testLegacyBlackistNameFilter() {
 
-		$blacklist_name = new \Yoast_ACF_Analysis_String_Store();
+		$blacklist_name = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
 			$blacklist_name,
-			new \Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
 		Filters\expectApplied( 'ysacf_exclude_fields' )
@@ -203,12 +206,12 @@ class Configuration_Test extends TestCase {
 	 */
 	public function testLegacyBlackistNameFilterInvalid() {
 
-		$blacklist_name = new \Yoast_ACF_Analysis_String_Store();
+		$blacklist_name = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
 			$blacklist_name,
-			new \Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
 		Filters\expectApplied( 'ysacf_exclude_fields' )
@@ -233,12 +236,12 @@ class Configuration_Test extends TestCase {
 	 */
 	public function testBlacklistNameFilterInvalid() {
 
-		$store = new \Yoast_ACF_Analysis_String_Store();
+		$store = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
 			$store,
-			new \Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_name' )
@@ -256,12 +259,12 @@ class Configuration_Test extends TestCase {
 	 */
 	public function testScraperConfigFilter() {
 		$config    = [];
-		$blacklist = new \Yoast_ACF_Analysis_String_Store();
+		$blacklist = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
+		$configuration = new Yoast_ACF_Analysis_Configuration(
 			$blacklist,
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\scraper_config' )
@@ -278,12 +281,12 @@ class Configuration_Test extends TestCase {
 	 * @return void
 	 */
 	public function testInvalidScraperConfigFilter() {
-		$blacklist = new \Yoast_ACF_Analysis_String_Store();
+		$blacklist = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
+		$configuration = new Yoast_ACF_Analysis_Configuration(
 			$blacklist,
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\scraper_config' )
@@ -305,10 +308,10 @@ class Configuration_Test extends TestCase {
 			->with( 1000 )
 			->andReturn( 9999 );
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store()
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
 		$this->assertSame( 9999, $configuration->get_refresh_rate() );
@@ -325,10 +328,10 @@ class Configuration_Test extends TestCase {
 			->with( 1000 )
 			->andReturn( 1 );
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store()
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store()
 		);
 
 		$this->assertSame( 200, $configuration->get_refresh_rate() );
@@ -340,12 +343,12 @@ class Configuration_Test extends TestCase {
 	 * @return void
 	 */
 	public function testFieldSelectorsFilter() {
-		$custom_store   = new \Yoast_ACF_Analysis_String_Store();
-		$field_selector = new \Yoast_ACF_Analysis_String_Store();
+		$custom_store   = new Yoast_ACF_Analysis_String_Store();
+		$field_selector = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store(),
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store(),
 			$field_selector
 		);
 
@@ -364,11 +367,11 @@ class Configuration_Test extends TestCase {
 	 */
 	public function testFieldSelectorsFilterInvalid() {
 
-		$store = new \Yoast_ACF_Analysis_String_Store();
+		$store = new Yoast_ACF_Analysis_String_Store();
 
-		$configuration = new \Yoast_ACF_Analysis_Configuration(
-			new \Yoast_ACF_Analysis_String_Store(),
-			new \Yoast_ACF_Analysis_String_Store(),
+		$configuration = new Yoast_ACF_Analysis_Configuration(
+			new Yoast_ACF_Analysis_String_Store(),
+			new Yoast_ACF_Analysis_String_Store(),
 			$store
 		);
 

--- a/tests/php/unit/Configuration/string-store-test.php
+++ b/tests/php/unit/Configuration/string-store-test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\ACF\Tests\Configuration;
 
 use PHPUnit\Framework\TestCase;
+use Yoast_ACF_Analysis_String_Store;
 
 /**
  * Class String_Store_Test.
@@ -17,7 +18,7 @@ class String_Store_Test extends TestCase {
 	 * @return \Yoast_ACF_Analysis_String_Store The blacklist string store.
 	 */
 	protected function getStore() {
-		return new \Yoast_ACF_Analysis_String_Store();
+		return new Yoast_ACF_Analysis_String_Store();
 	}
 
 	/**

--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\ACF\Tests\Dependencies;
 
 use Brain\Monkey;
 use PHPUnit\Framework\TestCase;
+use Yoast_ACF_Analysis_Dependency_ACF;
 
 /**
  * Class ACF_Dependency_Test.
@@ -38,7 +39,7 @@ class ACF_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testNoACFClassExists() {
-		$testee = new \Yoast_ACF_Analysis_Dependency_ACF();
+		$testee = new Yoast_ACF_Analysis_Dependency_ACF();
 
 		$this->assertFalse( $testee->is_met() );
 	}
@@ -49,7 +50,7 @@ class ACF_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testACFClassExists() {
-		$testee = new \Yoast_ACF_Analysis_Dependency_ACF();
+		$testee = new Yoast_ACF_Analysis_Dependency_ACF();
 
 		require_once __DIR__ . DIRECTORY_SEPARATOR . 'acf.php';
 
@@ -62,7 +63,7 @@ class ACF_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testAdminNotice() {
-		$testee = new \Yoast_ACF_Analysis_Dependency_ACF();
+		$testee = new Yoast_ACF_Analysis_Dependency_ACF();
 		$testee->register_notifications();
 
 		$this->assertTrue( has_action( 'admin_notices', [ $testee, 'message_plugin_not_activated' ] ) );

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\ACF\Tests\Dependencies;
 
 use Brain\Monkey;
 use PHPUnit\Framework\TestCase;
+use Yoast_ACF_Analysis_Dependency_Yoast_SEO;
 
 /**
  * Class Yoast_SEO_Dependency_Test.
@@ -52,7 +53,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testFail() {
-		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
+		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 
 		$this->assertFalse( $testee->is_met() );
 	}
@@ -65,7 +66,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	public function testPass() {
 		define( 'WPSEO_VERSION', '4.0.0' );
 
-		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
+		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertTrue( $testee->is_met() );
 	}
 
@@ -77,7 +78,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	public function testOldVersion() {
 		define( 'WPSEO_VERSION', '2.0.0' );
 
-		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
+		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertFalse( $testee->is_met() );
 	}
 
@@ -87,7 +88,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testAdminNotice() {
-		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
+		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$testee->register_notifications();
 
 		$this->assertTrue( has_action( 'admin_notices', [ $testee, 'message_plugin_not_activated' ] ) );
@@ -101,7 +102,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	public function testAdminNoticeMinimumVersion() {
 		define( 'WPSEO_VERSION', '2.0.0' );
 
-		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
+		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$testee->register_notifications();
 
 		$this->assertTrue( has_action( 'admin_notices', [ $testee, 'message_minimum_version' ] ) );

--- a/tests/php/unit/Doubles/failing-dependency.php
+++ b/tests/php/unit/Doubles/failing-dependency.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\WP\ACF\Tests\Doubles;
 
+use Yoast_ACF_Analysis_Dependency;
+
 /**
  * Class Failing_Dependency.
  */
-class Failing_Dependency implements \Yoast_ACF_Analysis_Dependency {
+class Failing_Dependency implements Yoast_ACF_Analysis_Dependency {
 
 	/**
 	 * Checks if this dependency is met.

--- a/tests/php/unit/Doubles/passing-dependency.php
+++ b/tests/php/unit/Doubles/passing-dependency.php
@@ -2,10 +2,12 @@
 
 namespace Yoast\WP\ACF\Tests\Doubles;
 
+use Yoast_ACF_Analysis_Dependency;
+
 /**
  * Class Passing_Dependency.
  */
-class Passing_Dependency implements \Yoast_ACF_Analysis_Dependency {
+class Passing_Dependency implements Yoast_ACF_Analysis_Dependency {
 
 	/**
 	 * Checks if this dependency is met.

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\ACF\Tests;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use Yoast_ACF_Analysis_Assets;
 
 /**
  * Class Assets_Test.
@@ -63,7 +64,7 @@ class Assets_Test extends TestCase {
 				]
 			);
 
-		$testee = new \Yoast_ACF_Analysis_Assets();
+		$testee = new Yoast_ACF_Analysis_Assets();
 		$testee->init();
 
 		$this->assertTrue( has_filter( 'admin_enqueue_scripts', [ $testee, 'enqueue_scripts' ] ) );

--- a/tests/php/unit/main-test.php
+++ b/tests/php/unit/main-test.php
@@ -4,6 +4,9 @@ namespace Yoast\WP\ACF\Tests;
 
 use Brain\Monkey;
 use PHPUnit\Framework\TestCase;
+use Yoast_ACF_Analysis_Facade;
+use AC_Yoast_SEO_ACF_Content_Analysis;
+use Yoast_ACF_Analysis_Configuration;
 
 /**
  * Class Main_Test.
@@ -38,16 +41,16 @@ class Main_Test extends TestCase {
 	 * @return void
 	 */
 	public function testInvalidConfig() {
-		$registry = \Yoast_ACF_Analysis_Facade::get_registry();
+		$registry = Yoast_ACF_Analysis_Facade::get_registry();
 
 		$registry->add( 'config', 'Invalid Config' );
 
-		$testee = new \AC_Yoast_SEO_ACF_Content_Analysis();
+		$testee = new AC_Yoast_SEO_ACF_Content_Analysis();
 		$testee->boot();
 
 		$result = $registry->get( 'config' );
 
 		$this->assertNotSame( 'Invalid Config', $result );
-		$this->assertInstanceOf( \Yoast_ACF_Analysis_Configuration::class, $result );
+		$this->assertInstanceOf( Yoast_ACF_Analysis_Configuration::class, $result );
 	}
 }

--- a/tests/php/unit/registry-test.php
+++ b/tests/php/unit/registry-test.php
@@ -3,6 +3,10 @@
 namespace Yoast\WP\ACF\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Yoast_ACF_Analysis_Facade;
+use Yoast_ACF_Analysis_Configuration;
+use Yoast_ACF_Analysis_String_Store;
+use Yoast_ACF_Analysis_Registry;
 
 /**
  * Class Registry_Test.
@@ -20,17 +24,17 @@ class Registry_Test extends TestCase {
 	 */
 	public function testSingleton() {
 
-		$first  = \Yoast_ACF_Analysis_Facade::get_registry();
-		$second = \Yoast_ACF_Analysis_Facade::get_registry();
+		$first  = Yoast_ACF_Analysis_Facade::get_registry();
+		$second = Yoast_ACF_Analysis_Facade::get_registry();
 
 		$this->assertSame( $first, $second );
 
 		$first->add(
 			'id',
-			new \Yoast_ACF_Analysis_Configuration(
-				new \Yoast_ACF_Analysis_String_Store(),
-				new \Yoast_ACF_Analysis_String_Store(),
-				new \Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_Configuration(
+				new Yoast_ACF_Analysis_String_Store(),
+				new Yoast_ACF_Analysis_String_Store(),
+				new Yoast_ACF_Analysis_String_Store()
 			)
 		);
 
@@ -47,7 +51,7 @@ class Registry_Test extends TestCase {
 		$id      = 'add';
 		$content = 'something';
 
-		$registry = new \Yoast_ACF_Analysis_Registry();
+		$registry = new Yoast_ACF_Analysis_Registry();
 
 		$this->assertNull( $registry->get( $id ) );
 

--- a/tests/php/unit/requirements-test.php
+++ b/tests/php/unit/requirements-test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Brain\Monkey\Functions;
 use Brain\Monkey\Filters;
 use PHPUnit\Framework\TestCase;
+use Yoast_ACF_Analysis_Requirements;
 use Yoast\WP\ACF\Tests\Doubles\Passing_Dependency;
 use Yoast\WP\ACF\Tests\Doubles\Failing_Dependency;
 
@@ -40,7 +41,7 @@ class Requirements_Test extends TestCase {
 	 * @return void
 	 */
 	public function testNoDependencies() {
-		$testee = new \Yoast_ACF_Analysis_Requirements();
+		$testee = new Yoast_ACF_Analysis_Requirements();
 		$this->assertTrue( $testee->are_met() );
 	}
 
@@ -53,7 +54,7 @@ class Requirements_Test extends TestCase {
 	 * @return void
 	 */
 	public function testPassingDependency() {
-		$testee = new \Yoast_ACF_Analysis_Requirements();
+		$testee = new Yoast_ACF_Analysis_Requirements();
 		$testee->add_dependency( new Passing_Dependency() );
 
 		$this->assertTrue( $testee->are_met() );
@@ -68,7 +69,7 @@ class Requirements_Test extends TestCase {
 	 * @return void
 	 */
 	public function testFailingDependency() {
-		$testee = new \Yoast_ACF_Analysis_Requirements();
+		$testee = new Yoast_ACF_Analysis_Requirements();
 		$testee->add_dependency( new Failing_Dependency() );
 
 		$this->assertFalse( $testee->are_met() );
@@ -83,7 +84,7 @@ class Requirements_Test extends TestCase {
 	 * @return void
 	 */
 	public function testMixedDependencies() {
-		$testee = new \Yoast_ACF_Analysis_Requirements();
+		$testee = new Yoast_ACF_Analysis_Requirements();
 		$testee->add_dependency( new Failing_Dependency() );
 		$testee->add_dependency( new Passing_Dependency() );
 


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Tests only.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.