### PR TITLE
QA: use FQN functions in namespaced files

### DIFF
--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -65,6 +65,6 @@ class ACF_Dependency_Test extends TestCase {
 		$testee = new \Yoast_ACF_Analysis_Dependency_ACF();
 		$testee->register_notifications();
 
-		$this->assertTrue( has_action( 'admin_notices', [ $testee, 'message_plugin_not_activated' ] ) );
+		$this->assertTrue( \has_action( 'admin_notices', [ $testee, 'message_plugin_not_activated' ] ) );
 	}
 }

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -63,7 +63,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testPass() {
-		define( 'WPSEO_VERSION', '4.0.0' );
+		\define( 'WPSEO_VERSION', '4.0.0' );
 
 		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertTrue( $testee->is_met() );
@@ -75,7 +75,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testOldVersion() {
-		define( 'WPSEO_VERSION', '2.0.0' );
+		\define( 'WPSEO_VERSION', '2.0.0' );
 
 		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertFalse( $testee->is_met() );
@@ -90,7 +90,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$testee->register_notifications();
 
-		$this->assertTrue( has_action( 'admin_notices', [ $testee, 'message_plugin_not_activated' ] ) );
+		$this->assertTrue( \has_action( 'admin_notices', [ $testee, 'message_plugin_not_activated' ] ) );
 	}
 
 	/**
@@ -99,11 +99,11 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testAdminNoticeMinimumVersion() {
-		define( 'WPSEO_VERSION', '2.0.0' );
+		\define( 'WPSEO_VERSION', '2.0.0' );
 
 		$testee = new \Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$testee->register_notifications();
 
-		$this->assertTrue( has_action( 'admin_notices', [ $testee, 'message_minimum_version' ] ) );
+		$this->assertTrue( \has_action( 'admin_notices', [ $testee, 'message_minimum_version' ] ) );
 	}
 }

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -53,7 +53,7 @@ class Assets_Test extends TestCase {
 	 * @return void
 	 */
 	public function testInitHook() {
-		define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_FILE', '/directory/file' );
+		\define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_FILE', '/directory/file' );
 		Functions\expect( 'get_plugin_data' )
 			->once()
 			->with( AC_SEO_ACF_ANALYSIS_PLUGIN_FILE )
@@ -66,6 +66,6 @@ class Assets_Test extends TestCase {
 		$testee = new \Yoast_ACF_Analysis_Assets();
 		$testee->init();
 
-		$this->assertTrue( has_filter( 'admin_enqueue_scripts', [ $testee, 'enqueue_scripts' ] ) );
+		$this->assertTrue( \has_filter( 'admin_enqueue_scripts', [ $testee, 'enqueue_scripts' ] ) );
 	}
 }


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Use fully qualified names for global functions to bypass PHP searching within the namespace first.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.