### PR TITLE
QA: use FQN constants in namespaced files

### DIFF
--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -51,7 +51,7 @@ class ACF_Dependency_Test extends TestCase {
 	public function testACFClassExists() {
 		$testee = new \Yoast_ACF_Analysis_Dependency_ACF();
 
-		require_once __DIR__ . DIRECTORY_SEPARATOR . 'acf.php';
+		require_once __DIR__ . \DIRECTORY_SEPARATOR . 'acf.php';
 
 		$this->assertTrue( $testee->is_met() );
 	}

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -56,7 +56,7 @@ class Assets_Test extends TestCase {
 		define( 'AC_SEO_ACF_ANALYSIS_PLUGIN_FILE', '/directory/file' );
 		Functions\expect( 'get_plugin_data' )
 			->once()
-			->with( AC_SEO_ACF_ANALYSIS_PLUGIN_FILE )
+			->with( \AC_SEO_ACF_ANALYSIS_PLUGIN_FILE )
 			->andReturn(
 				[
 					'Version' => '2.0.0',


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:
* _N/A_

## Relevant technical choices:

Use fully qualified names for global constants to bypass PHP searching within the namespace first.



## Test instructions

This PR can be tested by following these steps:
* _N/A_
    This is a code-only change and should have no effect on the functionality.