### PR TITLE
CS: don't use FQN in docblocks

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -33,7 +33,7 @@ class Yoast_ACF_Analysis_Assets {
 		/**
 		 * Yoast ACF plugin configuration.
 		 *
-		 * @var \Yoast_ACF_Analysis_Configuration
+		 * @var Yoast_ACF_Analysis_Configuration
 		 */
 		$config = Yoast_ACF_Analysis_Facade::get_registry()->get( 'config' );
 

--- a/tests/php/unit/Configuration/string-store-test.php
+++ b/tests/php/unit/Configuration/string-store-test.php
@@ -8,14 +8,14 @@ use Yoast_ACF_Analysis_String_Store;
 /**
  * Class String_Store_Test.
  *
- * @covers Yoast_ACF_Analysis_String_Store
+ * @covers \Yoast_ACF_Analysis_String_Store
  */
 class String_Store_Test extends TestCase {
 
 	/**
 	 * Gets the blacklist string store.
 	 *
-	 * @return \Yoast_ACF_Analysis_String_Store The blacklist string store.
+	 * @return Yoast_ACF_Analysis_String_Store The blacklist string store.
 	 */
 	protected function getStore() {
 		return new Yoast_ACF_Analysis_String_Store();


### PR DESCRIPTION

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

Don't use FQN in docblocks. Use unqualified names instead.

If the file is namespaced and the docblock comment involves a class from another namespace and no `use` statement is in place yet, add an import `use` statement.

Note: PHPUnit `@covers` tags *should* still be fully qualified (PHPUnit requirement)


## Test instructions

This PR can be tested by following these steps:

* _N/A_
