### PR TITLE
Rely on post-edit and term-edit instead of post-scraper and term-scraper

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -38,11 +38,11 @@ class Yoast_ACF_Analysis_Assets {
 		$config = Yoast_ACF_Analysis_Facade::get_registry()->get( 'config' );
 
 		// Post page enqueue.
-		if ( wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper' ) ) {
+		if ( wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit' ) ) {
 			wp_enqueue_script(
 				'yoast-acf-analysis-post',
 				plugins_url( '/js/yoast-acf-analysis.js', AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ),
-				[ 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'post-scraper', 'underscore' ],
+				[ 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit', 'underscore' ],
 				$this->plugin_data['Version'],
 				true
 			);
@@ -51,11 +51,11 @@ class Yoast_ACF_Analysis_Assets {
 		}
 
 		// Term page enqueue.
-		if ( wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper' ) ) {
+		if ( wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'term-edit' ) ) {
 			wp_enqueue_script(
 				'yoast-acf-analysis-term',
 				plugins_url( '/js/yoast-acf-analysis.js', AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ),
-				[ 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'term-scraper' ],
+				[ 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'term-edit' ],
 				$this->plugin_data['Version'],
 				true
 			);


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Compatibility with Yoast SEO 14.2 JavaScript changes. We used to depend on JavaScript files which aren't there anymore. We now depend on post-edit.js or term-edit.js.

## Test instructions

This PR can be tested by following these steps:

* In https://github.com/Yoast/wordpress-seo/pull/15083, Yoast SEO consolidates to less JavaScript files per screen.
* Checkout the `script-data` branch on Yoast SEO or `trunk` if the PR is merged already. 
* See the current stable of Yoast ACF doesn't load its JavaScript anymore.
* Checkout this PR. See it works again.
