### PR TITLE
Conditionally look for fields in metabox normal, side, or blocks

### DIFF
--- a/js/src/collect/collect-v5.js
+++ b/js/src/collect/collect-v5.js
@@ -8,11 +8,18 @@ module.exports = function() {
 
 	var innerFields = [];
 	var outerFields = [];
+	var acfFields = [];
 
-	// Return only fields in metabox areas (either below or side) or
-	// ACF block fields in the content (not in the sidebar, to prevent duplicates)
-	var parentContainer = jQuery( ".metabox-location-normal, .metabox-location-side, .acf-block-component.acf-block-body" );
-	var fields = _.map( acf.get_fields( false, parentContainer ), function( field ) {
+	if ( wp.data.select( "core/block-editor" ) ) {
+		// Return only fields in metabox areas (either below or side) or
+		// ACF block fields in the content (not in the sidebar, to prevent duplicates)
+		var parentContainer = jQuery( ".metabox-location-normal, .metabox-location-side, .acf-block-component.acf-block-body" );
+		acfFields = acf.get_fields( false, parentContainer );
+	} else {
+		acfFields = acf.get_fields();
+	}
+
+	var fields = _.map( acfFields, function( field ) {
 		var fieldData = jQuery.extend( true, {}, acf.get_data( jQuery( field ) ) );
 		fieldData.$el = jQuery( field );
 		fieldData.post_meta_key = fieldData.name;

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -224,11 +224,18 @@ module.exports = function() {
 
 	var innerFields = [];
 	var outerFields = [];
+	var acfFields = [];
 
-	// Return only fields in metabox areas (either below or side) or
-	// ACF block fields in the content (not in the sidebar, to prevent duplicates)
-	var parentContainer = jQuery( ".metabox-location-normal, .metabox-location-side, .acf-block-component.acf-block-body" );
-	var fields = _.map( acf.get_fields( false, parentContainer ), function( field ) {
+	if ( wp.data.select( "core/block-editor" ) ) {
+		// Return only fields in metabox areas (either below or side) or
+		// ACF block fields in the content (not in the sidebar, to prevent duplicates)
+		var parentContainer = jQuery( ".metabox-location-normal, .metabox-location-side, .acf-block-component.acf-block-body" );
+		acfFields = acf.get_fields( false, parentContainer );
+	} else {
+		acfFields = acf.get_fields();
+	}
+
+	var fields = _.map( acfFields, function( field ) {
 		var fieldData = jQuery.extend( true, {}, acf.get_data( jQuery( field ) ) );
 		fieldData.$el = jQuery( field );
 		fieldData.post_meta_key = fieldData.name;


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where using the classic editor caused an error due to not finding the block editor.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Follow the reproduction steps in https://yoast.atlassian.net/browse/QAK-1866 and verify that you cannot reproduce using this PR.
* Verify that for example the keyword density SEO check updates correctly using custom fields.

