### PR TITLE
Detect ACF blocks in preview, regardless of display mode

### DIFF
--- a/js/src/collect/collect-v5.js
+++ b/js/src/collect/collect-v5.js
@@ -32,7 +32,7 @@ module.exports = function() {
 	var blocks = wp.data.select( "core/block-editor" ).getBlocks();
 	var blockFields = _.map(
 		_.filter( blocks, function( block ) {
-			return block.name.startsWith( "acf/" ) && block.attributes.mode === "preview";
+			return block.name.startsWith( "acf/" ) && ( block.attributes.mode === "preview" || block.attributes.mode === "auto" );
 		} ),
 		function( block ) {
 			var fieldData = {

--- a/js/src/collect/collect-v5.js
+++ b/js/src/collect/collect-v5.js
@@ -41,7 +41,7 @@ module.exports = function() {
 		var blocks = wp.data.select( "core/block-editor" ).getBlocks();
 		var blockFields = _.map(
 			_.filter( blocks, function( block ) {
-				return block.name.startsWith( "acf/" ) && ( block.attributes.mode === "preview" || block.attributes.mode === "auto" );
+				return block.name.startsWith( "acf/" ) && jQuery( `[data-block="${block.clientId}"] .acf-block-preview` ).length === 1;
 			} ),
 			function( block ) {
 				var fieldData = {

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -257,7 +257,7 @@ module.exports = function() {
 		var blocks = wp.data.select( "core/block-editor" ).getBlocks();
 		var blockFields = _.map(
 			_.filter( blocks, function( block ) {
-				return block.name.startsWith( "acf/" ) && ( block.attributes.mode === "preview" || block.attributes.mode === "auto" );
+				return block.name.startsWith( "acf/" ) && jQuery( `[data-block="${block.clientId}"] .acf-block-preview` ).length === 1;
 			} ),
 			function( block ) {
 				var fieldData = {

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -248,7 +248,7 @@ module.exports = function() {
 	var blocks = wp.data.select( "core/block-editor" ).getBlocks();
 	var blockFields = _.map(
 		_.filter( blocks, function( block ) {
-			return block.name.startsWith( "acf/" ) && block.attributes.mode === "preview";
+			return block.name.startsWith( "acf/" ) && ( block.attributes.mode === "preview" || block.attributes.mode === "auto" );
 		} ),
 		function( block ) {
 			var fieldData = {


### PR DESCRIPTION
## Summary
Previously, only ACF block which were set to preview mode (the default mode) were communicated to Yoast SEO. However, any block mode can switch to the preview state, either automatically or manually, in the block editor. This patch just checks if such a preview exists, instead of relying on the block being in one of the modes.

This PR can be summarized in the following changelog entry:

* Fixes a bug where the content of ACF blocks in 'auto' mode was not taken into account when the block (automatically) switched to preview mode. Props to [TimVevida](https://github.com/TimVevida)

## Relevant technical choices:

During testing, I found that the order of the content passed to Yoast SEO can vary, blocks in the edit state are added as individual fields earlier in the process. Because the best results are achieved when all blocks are in the preview state, this does not seem a big deal. I do not have enough knowledge of Yoast SEO to know whether this affects SEO scoring. When needed, the fields could be sorted using [compareDocumentPosition](https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition).

## Test instructions

This PR can be tested by following these steps:

* Create ACF blocks with different modes (none/`preview`, `auto` or `edit`, [see the docs](https://www.advancedcustomfields.com/resources/acf_register_block_type/)).
* Add these blocks to a post/page.
* Check if all content is passed to Yoast SEO, regardless of view mode.

Fixes #261
