### PR TITLE
bump version to 14.5

### DIFF
--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -10,7 +10,7 @@
  */
 final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysis_Dependency {
 
-	const MINIMAL_REQUIRED_VERSION = 3.2;
+	const MINIMAL_REQUIRED_VERSION = 14.5;
 
 	/**
 	 * Checks if this dependency is met.


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* The minimal required version for Yoast SEO is now 14.5.

## Relevant technical choices:

* Changes made to localized scripts/objects in Yoast SEO required compatablity changes (made in https://github.com/Yoast/yoast-acf-analysis/pull/247 ). These changes mean that Yoast ACF Analysis only works with Yoast SEO 14.5 and onward.

