### PR TITLE
Set minimum Yoast SEO version to 14.6

### DIFF
--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -10,7 +10,7 @@
  */
 final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysis_Dependency {
 
-	const MINIMAL_REQUIRED_VERSION = 14.5;
+	const MINIMAL_REQUIRED_VERSION = 14.6;
 
 	/**
 	 * Checks if this dependency is met.

--- a/readme.txt
+++ b/readme.txt
@@ -59,8 +59,8 @@ Previously called Yoast ACF Analysis.
 
 Other:
 
-* Makes the plugin compatible with JavaScript changes introduced in Yoast SEO 14.5. We used to depend on JavaScript files which aren't there anymore. We now depend on `post-edit.js` or `term-edit.js`.
-* Sets the minimum supported Yoast SEO version to 14.5.
+* Makes the plugin compatible with JavaScript changes introduced in Yoast SEO 14.6. We used to depend on JavaScript files which aren't there anymore. We now depend on `post-edit.js` or `term-edit.js`.
+* Sets the minimum supported Yoast SEO version to 14.6.
 
 = 2.4.1 =
 

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -64,7 +64,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testPass() {
-		\define( 'WPSEO_VERSION', '14.5.0' );
+		\define( 'WPSEO_VERSION', '14.6.0' );
 
 		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertTrue( $testee->is_met() );
@@ -76,7 +76,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testOldVersion() {
-		\define( 'WPSEO_VERSION', '14.4.0' );
+		\define( 'WPSEO_VERSION', '14.5.0' );
 
 		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertFalse( $testee->is_met() );


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Set minimum Yoast SEO version to 14.6.

## Relevant technical choices:

* The planned release date for Yoast ACF 2.5 was together with Yoast SEO 14.5, because the refactor that resulted in the higher minimum Yoast SEO version would be released in 14.5. However, that refactor has moved to 14.6.

## Test instructions

This PR can be tested by following these steps:

*

Fixes #
