### PR TITLE
P3-147 Fix refresh analysis

### DIFF
--- a/grunt/config/eslint.js
+++ b/grunt/config/eslint.js
@@ -3,7 +3,7 @@ module.exports = {
 	plugin: {
 		src: [ "<%= files.js %>" ],
 		options: {
-			maxWarnings: 62,
+			maxWarnings: 58,
 		},
 	},
 	grunt: {
@@ -13,4 +13,3 @@ module.exports = {
 		},
 	},
 };
-

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -23,7 +23,7 @@ class Yoast_ACF_Analysis_Assets {
 	public function init() {
 		$this->plugin_data = get_plugin_data( AC_SEO_ACF_ANALYSIS_PLUGIN_FILE );
 
-		add_filter( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ], 11 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ], 11 );
 	}
 
 	/**
@@ -38,11 +38,14 @@ class Yoast_ACF_Analysis_Assets {
 		$config = Yoast_ACF_Analysis_Facade::get_registry()->get( 'config' );
 
 		// Post page enqueue.
-		if ( wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit' ) ) {
+		if (
+			wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit' ) ||
+			wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit-classic' )
+		) {
 			wp_enqueue_script(
 				'yoast-acf-analysis-post',
 				plugins_url( '/js/yoast-acf-analysis.js', AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ),
-				[ 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit', 'underscore' ],
+				[ 'jquery', 'underscore' ],
 				$this->plugin_data['Version'],
 				true
 			);

--- a/js/src/app.js
+++ b/js/src/app.js
@@ -52,26 +52,28 @@ App.prototype.acf4Listener = function( fieldSelectors, wysiwygSelector, fieldSel
 App.prototype.acf5Listener = function() {
 	replaceVars.updateReplaceVars( collect );
 
-	var self = this;
+	var that = this;
 
 	// Use ACF Models introduced in ACF version 5.7.
+	/* eslint-disable no-unused-vars */
 	var acfModelInstance = new acf.Model( {
-		wait: 'ready',
+		wait: "ready",
 		events: {
-			'input': 'onInput',
+			input: "onInput",
 		},
 		onInput: this.refreshAnalysisAndReplaceVars.bind( this ),
 	} );
+	/* eslint-enable no-unused-vars */
 
 	// The ACF Wysiwyg field needs to be handled after TinyMCE is initialized.
-	jQuery( document ).on( 'tinymce-editor-init', function( event, editor ) {
+	jQuery( document ).on( "tinymce-editor-init", function( event, editor ) {
 		/*
 		 * TinyMCE supports the native `input` event but doesn't always fire it
 		 * when pasting: added a specific `paste` event. Also, added TinyMCE specific
 		 * events to support the undo and redo actions.
 		 */
-		editor.on( 'input paste undo redo', function() {
-			self.refreshAnalysisAndReplaceVars();
+		editor.on( "input paste undo redo", function() {
+			that.refreshAnalysisAndReplaceVars();
 		} );
 	} );
 
@@ -79,25 +81,25 @@ App.prototype.acf5Listener = function() {
 	 * ACF `append` global action: Triggered when new HTML is added to the page.
 	 * For example, when adding a Repeater row or a Flexible content layout.
 	 */
-	acf.addAction( 'append', this.refreshAnalysisAndReplaceVars.bind( this ) );
+	acf.addAction( "append", this.refreshAnalysisAndReplaceVars.bind( this ) );
 
 	/*
 	 * ACF `remove` global action: Triggered when HTML is removed from the page.
 	 * For example, when removing a Repeater row or a Flexible content layout.
 	 */
-	acf.addAction( 'remove', this.refreshAnalysisAndReplaceVars.bind( this ) );
+	acf.addAction( "remove", this.refreshAnalysisAndReplaceVars.bind( this ) );
 
 	/*
 	 * ACF `sortstop` global action: Triggered when a field is reordered.
 	 * For example, when reordering Repeater rows or Flexible content layouts.
 	 */
-	acf.addAction( 'sortstop', this.refreshAnalysisAndReplaceVars.bind( this ) );
+	acf.addAction( "sortstop", this.refreshAnalysisAndReplaceVars.bind( this ) );
 };
 
 App.prototype.refreshAnalysisAndReplaceVars = function() {
 	this.maybeRefresh();
 	replaceVars.updateReplaceVars.bind( this, collect );
-}
+};
 
 App.prototype.bindListeners = function() {
 	if ( helper.acf_version >= 5 ) {
@@ -120,7 +122,9 @@ App.prototype.maybeRefresh = function() {
 
 	analysisTimeout = window.setTimeout( function() {
 		if ( config.debug ) {
+			/* eslint-disable no-console */
 			console.log( "Recalculate..." + new Date() + "(Internal)" );
+			/* eslint-enable no-console */
 		}
 
 		YoastSEO.app.pluginReloaded( config.pluginName );

--- a/js/src/app.js
+++ b/js/src/app.js
@@ -52,9 +52,31 @@ App.prototype.acf4Listener = function( fieldSelectors, wysiwygSelector, fieldSel
 App.prototype.acf5Listener = function() {
 	replaceVars.updateReplaceVars( collect );
 
-	acf.add_action( "change remove append sortstop", this.maybeRefresh );
-	acf.add_action( "change remove append sortstop", replaceVars.updateReplaceVars.bind( this, collect ) );
+	var self = this;
+
+	// Use ACF Models introduced in ACF version 5.7.
+	var acfModelInstance = new acf.Model( {
+		wait: 'ready',
+		events: {
+			'input': 'onInput',
+		},
+		onInput: function() {
+			self.refreshAnalysisAndReplaceVars();
+		},
+	} );
+
+	// The ACF Wysiwyg field needs some special treatment.
+	jQuery( document ).on( 'tinymce-editor-init', function( event, editor ) {
+		editor.on( 'input paste undo redo', function() {
+			self.refreshAnalysisAndReplaceVars();
+		} );
+	} );
 };
+
+App.prototype.refreshAnalysisAndReplaceVars = function() {
+	this.maybeRefresh();
+	replaceVars.updateReplaceVars.bind( this, collect );
+}
 
 App.prototype.bindListeners = function() {
 	if ( helper.acf_version >= 5 ) {

--- a/js/src/app.js
+++ b/js/src/app.js
@@ -60,17 +60,38 @@ App.prototype.acf5Listener = function() {
 		events: {
 			'input': 'onInput',
 		},
-		onInput: function() {
-			self.refreshAnalysisAndReplaceVars();
-		},
+		onInput: this.refreshAnalysisAndReplaceVars.bind( this ),
 	} );
 
-	// The ACF Wysiwyg field needs some special treatment.
+	// The ACF Wysiwyg field needs to be handled after TinyMCE is initialized.
 	jQuery( document ).on( 'tinymce-editor-init', function( event, editor ) {
+		/*
+		 * TinyMCE supports the native `input` event but doesn't always fire it
+		 * when pasting: added a specific `paste` event. Also, added TinyMCE specific
+		 * events to support the undo and redo actions.
+		 */
 		editor.on( 'input paste undo redo', function() {
 			self.refreshAnalysisAndReplaceVars();
 		} );
 	} );
+
+	/*
+	 * ACF `append` global action: Triggered when new HTML is added to the page.
+	 * For example, when adding a Repeater row or a Flexible content layout.
+	 */
+	acf.addAction( 'append', this.refreshAnalysisAndReplaceVars.bind( this ) );
+
+	/*
+	 * ACF `remove` global action: Triggered when HTML is removed from the page.
+	 * For example, when removing a Repeater row or a Flexible content layout.
+	 */
+	acf.addAction( 'remove', this.refreshAnalysisAndReplaceVars.bind( this ) );
+
+	/*
+	 * ACF `sortstop` global action: Triggered when a field is reordered.
+	 * For example, when reordering Repeater rows or Flexible content layouts.
+	 */
+	acf.addAction( 'sortstop', this.refreshAnalysisAndReplaceVars.bind( this ) );
 };
 
 App.prototype.refreshAnalysisAndReplaceVars = function() {

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -61,17 +61,38 @@ App.prototype.acf5Listener = function() {
 		events: {
 			'input': 'onInput',
 		},
-		onInput: function() {
-			self.refreshAnalysisAndReplaceVars();
-		},
+		onInput: this.refreshAnalysisAndReplaceVars.bind( this ),
 	} );
 
-	// The ACF Wysiwyg field needs some special treatment.
+	// The ACF Wysiwyg field needs to be handled after TinyMCE is initialized.
 	jQuery( document ).on( 'tinymce-editor-init', function( event, editor ) {
+		/*
+		 * TinyMCE supports the native `input` event but doesn't always fire it
+		 * when pasting: added a specific `paste` event. Also, added TinyMCE specific
+		 * events to support the undo and redo actions.
+		 */
 		editor.on( 'input paste undo redo', function() {
 			self.refreshAnalysisAndReplaceVars();
 		} );
 	} );
+
+	/*
+	 * ACF `append` global action: Triggered when new HTML is added to the page.
+	 * For example, when adding a Repeater row or a Flexible content layout.
+	 */
+	acf.addAction( 'append', this.refreshAnalysisAndReplaceVars.bind( this ) );
+
+	/*
+	 * ACF `remove` global action: Triggered when HTML is removed from the page.
+	 * For example, when removing a Repeater row or a Flexible content layout.
+	 */
+	acf.addAction( 'remove', this.refreshAnalysisAndReplaceVars.bind( this ) );
+
+	/*
+	 * ACF `sortstop` global action: Triggered when a field is reordered.
+	 * For example, when reordering Repeater rows or Flexible content layouts.
+	 */
+	acf.addAction( 'sortstop', this.refreshAnalysisAndReplaceVars.bind( this ) );
 };
 
 App.prototype.refreshAnalysisAndReplaceVars = function() {

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -53,26 +53,28 @@ App.prototype.acf4Listener = function( fieldSelectors, wysiwygSelector, fieldSel
 App.prototype.acf5Listener = function() {
 	replaceVars.updateReplaceVars( collect );
 
-	var self = this;
+	var that = this;
 
 	// Use ACF Models introduced in ACF version 5.7.
+	/* eslint-disable no-unused-vars */
 	var acfModelInstance = new acf.Model( {
-		wait: 'ready',
+		wait: "ready",
 		events: {
-			'input': 'onInput',
+			input: "onInput",
 		},
 		onInput: this.refreshAnalysisAndReplaceVars.bind( this ),
 	} );
+	/* eslint-enable no-unused-vars */
 
 	// The ACF Wysiwyg field needs to be handled after TinyMCE is initialized.
-	jQuery( document ).on( 'tinymce-editor-init', function( event, editor ) {
+	jQuery( document ).on( "tinymce-editor-init", function( event, editor ) {
 		/*
 		 * TinyMCE supports the native `input` event but doesn't always fire it
 		 * when pasting: added a specific `paste` event. Also, added TinyMCE specific
 		 * events to support the undo and redo actions.
 		 */
-		editor.on( 'input paste undo redo', function() {
-			self.refreshAnalysisAndReplaceVars();
+		editor.on( "input paste undo redo", function() {
+			that.refreshAnalysisAndReplaceVars();
 		} );
 	} );
 
@@ -80,25 +82,25 @@ App.prototype.acf5Listener = function() {
 	 * ACF `append` global action: Triggered when new HTML is added to the page.
 	 * For example, when adding a Repeater row or a Flexible content layout.
 	 */
-	acf.addAction( 'append', this.refreshAnalysisAndReplaceVars.bind( this ) );
+	acf.addAction( "append", this.refreshAnalysisAndReplaceVars.bind( this ) );
 
 	/*
 	 * ACF `remove` global action: Triggered when HTML is removed from the page.
 	 * For example, when removing a Repeater row or a Flexible content layout.
 	 */
-	acf.addAction( 'remove', this.refreshAnalysisAndReplaceVars.bind( this ) );
+	acf.addAction( "remove", this.refreshAnalysisAndReplaceVars.bind( this ) );
 
 	/*
 	 * ACF `sortstop` global action: Triggered when a field is reordered.
 	 * For example, when reordering Repeater rows or Flexible content layouts.
 	 */
-	acf.addAction( 'sortstop', this.refreshAnalysisAndReplaceVars.bind( this ) );
+	acf.addAction( "sortstop", this.refreshAnalysisAndReplaceVars.bind( this ) );
 };
 
 App.prototype.refreshAnalysisAndReplaceVars = function() {
 	this.maybeRefresh();
 	replaceVars.updateReplaceVars.bind( this, collect );
-}
+};
 
 App.prototype.bindListeners = function() {
 	if ( helper.acf_version >= 5 ) {
@@ -121,7 +123,9 @@ App.prototype.maybeRefresh = function() {
 
 	analysisTimeout = window.setTimeout( function() {
 		if ( config.debug ) {
+			/* eslint-disable no-console */
 			console.log( "Recalculate..." + new Date() + "(Internal)" );
+			/* eslint-enable no-console */
 		}
 
 		YoastSEO.app.pluginReloaded( config.pluginName );

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -53,9 +53,31 @@ App.prototype.acf4Listener = function( fieldSelectors, wysiwygSelector, fieldSel
 App.prototype.acf5Listener = function() {
 	replaceVars.updateReplaceVars( collect );
 
-	acf.add_action( "change remove append sortstop", this.maybeRefresh );
-	acf.add_action( "change remove append sortstop", replaceVars.updateReplaceVars.bind( this, collect ) );
+	var self = this;
+
+	// Use ACF Models introduced in ACF version 5.7.
+	var acfModelInstance = new acf.Model( {
+		wait: 'ready',
+		events: {
+			'input': 'onInput',
+		},
+		onInput: function() {
+			self.refreshAnalysisAndReplaceVars();
+		},
+	} );
+
+	// The ACF Wysiwyg field needs some special treatment.
+	jQuery( document ).on( 'tinymce-editor-init', function( event, editor ) {
+		editor.on( 'input paste undo redo', function() {
+			self.refreshAnalysisAndReplaceVars();
+		} );
+	} );
 };
+
+App.prototype.refreshAnalysisAndReplaceVars = function() {
+	this.maybeRefresh();
+	replaceVars.updateReplaceVars.bind( this, collect );
+}
 
 App.prototype.bindListeners = function() {
 	if ( helper.acf_version >= 5 ) {

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -67,6 +67,6 @@ class Assets_Test extends TestCase {
 		$testee = new Yoast_ACF_Analysis_Assets();
 		$testee->init();
 
-		$this->assertTrue( \has_filter( 'admin_enqueue_scripts', [ $testee, 'enqueue_scripts' ] ) );
+		$this->assertTrue( \has_action( 'admin_enqueue_scripts', [ $testee, 'enqueue_scripts' ] ) );
 	}
 }


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where changes to the content of the ACF fields didn't trigger a live refresh ot the Yoast SEO analysis.

## Relevant technical choices:

1. I'm using the new ACF JavaScript API introduced in ACF 5.7: https://www.advancedcustomfields.com/resources/javascript-api/
2. **important: this means the new code is not compatible with previous ACF versions** (the current version is 5.9.1)
3. I'm using the `acf.Model` API with an `input` event: this event fires for changes to _any_ native form element including checkboxes, radio buttons, select elements. Changing the value of these form elements will trigger an analysis refresh even if, actually, there's no change in the post content. I opted to not filter out these form elements to keep things simple and because you never know (e.g. checking a checkbox _could_ add some content in some edge cases?).
4. I disabled the ESLint `no-unused-vars` when creating the new `acf.Model` instance because I wouldn't know how to do it otherwise.
5. I made sure acf analysis works in Classic Editor: it stopped working after https://github.com/Yoast/wordpress-seo/pull/15842 because the `post-edit` script now uses two different handles: `post-edit` and `post-edit-classic`
6. Changed a `add_filter()` call to `add_action()`: although the former works, the latter is the correct one to use because `admin_enqueue_scripts` is an action
7. Removed the `yoast-acf-analysis` script dependency for `post-edit` to simplify (see point 5) and because there's already a conditional to check whether `post-edit` is enqueued


## Test instructions

**Preliminary steps:**
- This PR needs to be tested with various types of ACF fields. Some fields are only available on the PRO version so I'd recommend to test with the PRO version
- Ask internally for a licensed version of latest Advanced Custom Fields PRO install it and activate it
- Install and activate Yoast SEO 
- Clone this repository https://github.com/Yoast/yoast-acf-analysis in your WordPress plugins directory and activate ACF Content Analysis for Yoast SEO
- Switch to this branch and build by running `npm run build`
- Go to WordPress > Custom Fields and build a field group or, better, import the field group I used for testing by importing the attached json file. You can import it on the page: Custom Fields > Tools > Import Field Groups
- After the import you should have a group field ready for testing purposes. Make sure it's set to be displayed both on Posts and Taxonomies: Edit the field group and check under the "Location" meta box:

<img width="968" alt="Screenshot 2020-09-08 at 13 57 39" src="https://user-images.githubusercontent.com/1682452/92473781-58e8b900-f1db-11ea-8f51-fddf7d436d1b.png">

**Actual testing:**
- the main goal of testing is to check that changes to the ACF fields trigger a **live** refresh of the analysis
- edit a post that contains little text
- open the SEO analysis and use as a reference the Text length assessment (or other assessment if you prefer: text length is easier to check)
- the assessment will initially report: "The text contains {nn} words". Take note of the number of words.
- in all the ACF fields where you can enter text, check that:
  - entering and deleting text triggers an analysis refresh: note the number of words in the text length assessment must change
  - pasting and cutting text (with both mouse right click and keyboard) does the same
- for the Wysiwyg field (which is powered by TinyMCE) check that any change to the text, including undo and redo actions, does the same
- switch the Wysiwyg field to "Text" mode and check the same as above
- for the "Repeater" and "Flexible content" fields:
  - check that adding a row triggers the analysis refresh: luckily, acf-analysis already dumps in the browser's console some data when the analysis is refreshed: if you see that dump, it means it works 
- check that removing a row does the same
- check that any change to the text within the "Repeater" and "Flexible content" triggers the analysis refresh and the text length assessment words number gets updated
- test any other possible scenario I may have forgotten to mention
- **repeat the test with Classic Editor**
- **repeat the test on the edit term page (edit a category or a tag)**

JSON file with the group field:
[acf-export-for-PRO.json.zip](https://github.com/Yoast/yoast-acf-analysis/files/5188204/acf-export-for-PRO.json.zip)

Fixes [P3-147]
