### PR TITLE
Don't activate the plugin if ACF < 5.7 is running

### DIFF
--- a/inc/dependencies/dependency-acf.php
+++ b/inc/dependencies/dependency-acf.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Checks wether ACF is installed.
+ * Checks whether ACF is installed.
  */
 final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Dependency {
 
@@ -17,6 +17,10 @@ final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Depe
 	 */
 	public function is_met() {
 		if ( ! class_exists( 'acf' ) ) {
+			return false;
+		}
+
+		if ( defined( 'ACF_VERSION' ) && version_compare( ACF_VERSION, '5.7.0', '<' ) ) {
 			return false;
 		}
 
@@ -36,7 +40,7 @@ final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Depe
 	public function message_plugin_not_activated() {
 		$message = sprintf(
 			/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO, %2$s resolves to Advanced Custom Fields */
-			__( '%1$s requires %2$s (free or pro) to be installed and activated.', 'acf-content-analysis-for-yoast-seo' ),
+			__( '%1$s requires %2$s (free or pro) 5.7 or higher to be installed and activated.', 'acf-content-analysis-for-yoast-seo' ),
 			'ACF Content Analysis for Yoast SEO',
 			'Advanced Custom Fields'
 		);


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Doesn't activate the plugin if ACF < 5.7 is detected.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Install ACF < 5.7.
* Try to activate the ACF for Yoast Plugin.
* See a notice on top of your screen:
<img width="833" alt="Schermafbeelding 2020-09-17 om 09 50 49" src="https://user-images.githubusercontent.com/17744553/93436615-51a46800-f8cb-11ea-91ad-c60dbbd165f0.png">

* Note that the plugin still looks activated in the overview. However, it's not doing anything in the editor. This is consistent with what happens when you haven't ACF installed at all. If you have installed ACF 5.0-5.6, this means there won't be console errors in the editor saying `acf.Model is not a constructor`.
* Install ACF > 5.7.
* Don't see a notice
* Verify that the plugin does its thing in the editor.

Fixes #
