### PR TITLE
Tests: make the testsuite compatible with PHPUnit 9 and test against PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpcs.xml
 .phpcs.xml
 .cache/phpcs.cache
 phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
     - php: 7.0
       env: PHPUNIT=1
     - php: "nightly"
+      env: PHPUNIT=1
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -43,9 +44,11 @@ before_install:
 install:
 - |
   if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
-    composer install --prefer-dist --no-interaction --ignore-platform-reqs
+    travis_retry composer config platform --unset
+    # Update the locked-in PHPUnit version to allow for testing on PHP 8.
+    travis_retry composer require --dev phpunit/phpunit:"^9.0" --update-with-dependencies --no-interaction --ignore-platform-reqs
   else
-    composer install --prefer-dist --no-interaction
+    travis_retry composer install --no-interaction
   fi
 - if [[ "$CHECKJS" == "1" ]]; then yarn global add grunt-cli; fi
 - if [[ "$CHECKJS" == "1" ]]; then yarn install; fi

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
   },
   "require-dev": {
     "brain/monkey": "^2.4.0",
-    "phpunit/phpunit": "^5.4 || ^6.0 || ^7.0",
+    "phpunit/phpunit": "^5.4 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
     "yoast/yoastcs": "^2.0.0",
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "php-parallel-lint/php-console-highlighter": "^0.5"

--- a/composer.lock
+++ b/composer.lock
@@ -130,16 +130,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.11",
+            "version": "2.1.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "ff7aae02f1c5492716fe13d59de4cfc389b8c4b0"
+                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/ff7aae02f1c5492716fe13d59de4cfc389b8c4b0",
-                "reference": "ff7aae02f1c5492716fe13d59de4cfc389b8c4b0",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/b98e046dd4c0acc34a0846604f06f6111654d9ea",
+                "reference": "b98e046dd4c0acc34a0846604f06f6111654d9ea",
                 "shasum": ""
             },
             "require": {
@@ -170,7 +170,7 @@
                 "runkit",
                 "testing"
             ],
-            "time": "2019-10-26T07:10:56+00:00"
+            "time": "2019-12-22T17:52:09+00:00"
         },
         {
             "name": "brain/monkey",
@@ -360,20 +360,20 @@
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad"
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/776503d3a8e85d4f9a1148614f95b7a608b046ad",
-                "reference": "776503d3a8e85d4f9a1148614f95b7a608b046ad",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3|^7.0"
+                "php": "^5.3|^7.0|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -381,14 +381,13 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "1.3.3",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "^1.0"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -398,41 +397,40 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD"
+                "BSD-3-Clause"
             ],
             "description": "This is the PHP port of Hamcrest Matchers",
             "keywords": [
                 "test"
             ],
-            "time": "2016-01-20T08:20:44+00:00"
+            "time": "2020-07-09T08:09:16+00:00"
         },
         {
             "name": "mockery/mockery",
-            "version": "1.3.0",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "5571962a4f733fbb57bede39778f71647fae8e66"
+                "reference": "60fa2f67f6e4d3634bb4a45ff3171fa52215800d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/5571962a4f733fbb57bede39778f71647fae8e66",
-                "reference": "5571962a4f733fbb57bede39778f71647fae8e66",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/60fa2f67f6e4d3634bb4a45ff3171fa52215800d",
+                "reference": "60fa2f67f6e4d3634bb4a45ff3171fa52215800d",
                 "shasum": ""
             },
             "require": {
-                "hamcrest/hamcrest-php": "~2.0",
+                "hamcrest/hamcrest-php": "^2.0.1",
                 "lib-pcre": ">=7.0",
-                "php": ">=5.6.0",
-                "sebastian/comparator": "^1.2.4|^3.0"
+                "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5.7.10|~6.5|~7.0|~8.0"
+                "phpunit/phpunit": "^5.7.10|^6.5|^7.5|^8.5|^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -470,7 +468,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2019-11-24T07:54:50+00:00"
+            "time": "2020-08-11T18:10:21+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -972,38 +970,38 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1031,7 +1029,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1280,6 +1278,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-12-04T08:55:13+00:00"
         },
         {
@@ -1990,16 +1989,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
                 "shasum": ""
             },
             "require": {
@@ -2011,7 +2010,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2044,20 +2047,34 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.27",
+            "version": "v3.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996"
+                "reference": "ec3c2ac4d881a4684c1f0317d2107f1a4152bad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/212a27b731e5bfb735679d1ffaac82bd6a1dc996",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ec3c2ac4d881a4684c1f0317d2107f1a4152bad9",
+                "reference": "ec3c2ac4d881a4684c1f0317d2107f1a4152bad9",
                 "shasum": ""
             },
             "require": {
@@ -2103,36 +2120,48 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-25T07:48:46+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-18T15:58:55+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
+                "php": "^5.3.3 || ^7.0 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -2154,7 +2183,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20103c7660983cb713c74013da342dde",
+    "content-hash": "3d5e430d861960066bfdfbd3d2d9ab2e",
     "packages": [
         {
             "name": "composer/installers",

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -20,9 +20,11 @@ class Configuration_Test extends TestCase {
 	/**
 	 * Sets up test fixtures.
 	 *
+	 * @before
+	 *
 	 * @return void
 	 */
-	protected function setUp() {
+	protected function setUpFixtures() {
 		parent::setUp();
 		Monkey\setUp();
 	}
@@ -30,9 +32,11 @@ class Configuration_Test extends TestCase {
 	/**
 	 * Tears down test fixtures previously setup.
 	 *
+	 * @after
+	 *
 	 * @return void
 	 */
-	protected function tearDown() {
+	protected function tearDownFixtures() {
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/php/unit/Configuration/string-store-test.php
+++ b/tests/php/unit/Configuration/string-store-test.php
@@ -30,7 +30,7 @@ class String_Store_Test extends TestCase {
 		$store  = $this->getStore();
 		$result = $store->to_array();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assertTypeArray( $result );
 		$this->assertEmpty( $result );
 	}
 
@@ -112,7 +112,7 @@ class String_Store_Test extends TestCase {
 
 		$result = $store->to_array();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assertTypeArray( $result );
 		$this->assertEmpty( $result );
 	}
 
@@ -141,7 +141,7 @@ class String_Store_Test extends TestCase {
 
 		$result = $store->to_array();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assertTypeArray( $result );
 		$this->assertEmpty( $result );
 	}
 
@@ -168,5 +168,28 @@ class String_Store_Test extends TestCase {
 		$store = $this->getStore();
 
 		$this->assertFalse( $store->remove( 'test' ) );
+	}
+
+	/**
+	 * Helper method to test that an arbitrary result is of the type array.
+	 *
+	 * PHPUnit 7.5 introduced a new set of methods to test the type of a variable.
+	 * As of PHPUnit 8.0, the old `assert[Not]InternalType()` methods was deprecated
+	 * and they were removed in PHPUnit 9.0.
+	 * This is a simple wrapper to get round this for the limited functionality used
+	 * by this test.
+	 *
+	 * @param mixed $result The result to check the type of.
+	 *
+	 * @return void.
+	 */
+	protected function assertTypeArray( $result ) {
+		if ( method_exists( $this, 'assertIsArray' ) ) {
+			// PHPUnit 7.5+.
+			$this->assertIsArray( $result );
+			return;
+		}
+
+		$this->assertInternalType( 'array', $result );
 	}
 }

--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -16,9 +16,11 @@ class ACF_Dependency_Test extends TestCase {
 	/**
 	 * Sets up test fixtures.
 	 *
+	 * @before
+	 *
 	 * @return void
 	 */
-	protected function setUp() {
+	protected function setUpFixtures() {
 		parent::setUp();
 		Monkey\setUp();
 	}
@@ -26,9 +28,11 @@ class ACF_Dependency_Test extends TestCase {
 	/**
 	 * Tears down test fixtures previously setup.
 	 *
+	 * @after
+	 *
 	 * @return void
 	 */
-	protected function tearDown() {
+	protected function tearDownFixtures() {
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -30,9 +30,11 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	/**
 	 * Sets up test fixtures.
 	 *
+	 * @before
+	 *
 	 * @return void
 	 */
-	protected function setUp() {
+	protected function setUpFixtures() {
 		parent::setUp();
 		Monkey\setUp();
 	}
@@ -40,9 +42,11 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	/**
 	 * Tears down test fixtures previously setup.
 	 *
+	 * @after
+	 *
 	 * @return void
 	 */
-	protected function tearDown() {
+	protected function tearDownFixtures() {
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -31,9 +31,11 @@ class Assets_Test extends TestCase {
 	/**
 	 * Sets up test fixtures.
 	 *
+	 * @before
+	 *
 	 * @return void
 	 */
-	protected function setUp() {
+	protected function setUpFixtures() {
 		parent::setUp();
 		Monkey\setUp();
 	}
@@ -41,9 +43,11 @@ class Assets_Test extends TestCase {
 	/**
 	 * Tears down test fixtures previously setup.
 	 *
+	 * @after
+	 *
 	 * @return void
 	 */
-	protected function tearDown() {
+	protected function tearDownFixtures() {
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/php/unit/main-test.php
+++ b/tests/php/unit/main-test.php
@@ -16,9 +16,11 @@ class Main_Test extends TestCase {
 	/**
 	 * Sets up test fixtures.
 	 *
+	 * @before
+	 *
 	 * @return void
 	 */
-	protected function setUp() {
+	protected function setUpFixtures() {
 		parent::setUp();
 		Monkey\setUp();
 	}
@@ -26,9 +28,11 @@ class Main_Test extends TestCase {
 	/**
 	 * Tears down test fixtures previously setup.
 	 *
+	 * @after
+	 *
 	 * @return void
 	 */
-	protected function tearDown() {
+	protected function tearDownFixtures() {
 		Monkey\tearDown();
 		parent::tearDown();
 	}

--- a/tests/php/unit/requirements-test.php
+++ b/tests/php/unit/requirements-test.php
@@ -16,8 +16,12 @@ class Requirements_Test extends TestCase {
 
 	/**
 	 * Sets up test fixtures.
+	 *
+	 * @before
+	 *
+	 * @return void
 	 */
-	protected function setUp() {
+	protected function setUpFixtures() {
 		parent::setUp();
 		Monkey\setUp();
 
@@ -26,8 +30,12 @@ class Requirements_Test extends TestCase {
 
 	/**
 	 * Tears down test fixtures previously set up.
+	 *
+	 * @after
+	 *
+	 * @return void
 	 */
-	protected function tearDown() {
+	protected function tearDownFixtures() {
 		Monkey\tearDown();
 		parent::tearDown();
 	}


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Preparation for compatibility with PHP 8

## Relevant technical choices:

### Composer: update the dependencies of the test dependencies

Update the `composer.lock` file with the latest dependencies related to the test suite.
```
composer update --dev brain/monkey phpunit/phpunit --with-dependencies
```

Note: the update is still based on `platform: php 5.6`, but some of the more recent sub-dependencies have widened their PHP version constraints, which makes getting the tests running on PHP 8 easier.

### Tests: use annotations instead of fixtures

In PHPUnit 8.x, the `setUpBeforeClass()`, `tearDownAfterClass()`, `setUp()` and `tearDown()` methods have received type declarations,with a return type `void`, making it neigh impossible to implement this in a cross-version manner as the `void` return type is not available until PHP 7.1.

However, PHPUnit also supports `@beforeClass`, `@afterClass`, `@before` and `@after` annotations to run arbitrary methods for setting things up/tearing things down. Those annotations have been around forever and are supported all the way back to PHPUnit 4.x.

So instead of doing convoluted things with extending different classes for different PHPUnit versions or creating classes on the fly for this, by renaming the fixture related methods and using the PHPUnit annotations, the unit test suite becomes compatible with PHPUnit 8.x without much effort.

### Tests: implement work-around for remaining PHPUnit cross-version issue

PHPUnit 9 removed the `assertInternalType()` method in favour of more specific methods, which were introduced in PHPUnit 8.

As this test suite only uses this assertion in one test file, a simple helper method with an if/else does the trick.

### Composer: allow installation of PHPUnit 8 and 9

Now the tests have been made cross-version compatible with PHPUnit 8 and 9, allow installation of those versions by widening the version restraints in the `composer.json` file.

PHPUnit 8 introduces a form of caching to PHPUnit, so adding this cache file to the `.gitignore` file.

### Travis: run the tests against PHP 8/nightly

Now the tests are fully compatible with PHPUnit 9, the test suite can be run on PHP 8.

As not all dependencies of PHPUnit have tagged a new version which allows for PHP 8 yet, we do need to `ignore-platform-reqs` for the time being.

Includes adding `travis_retry` to `composer install`-like commands to get round builds stalling on the connection with Packagist, especially on older PHP versions.



## Test instructions

This PR can be tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run and 3) the tests pass.

To test locally, it will be simplest to:
1. Download phars of PHPUnit [7](https://phar.phpunit.de/phpunit-7.phar)/[8](https://phar.phpunit.de/phpunit-8.phar)/[9](https://phar.phpunit.de/phpunit-9.phar) and save them somewhere in the system path or in the root directory of this project (an exclude them from Git).
2. On a recent PHP 7.4.x version, run the tests using each of the downloaded phars:
    ```
    phpunit7.phar
    phpunit8.phar
    phpunit9.phar
    ```
    The tests on each version should run without any warnings and pass. This confirms the PHPUnit cross-version compatibility.
3. On a recent PHP 8 pre-release, run the tests again, though now only using the `phpunit9.phar`.
    The tests should pass, which confirms PHP 8 compatibility for the code covered by tests.