### PR TITLE
Composer: update YoastCS and Composer Installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=5.6",
-    "composer/installers": "~1.0"
+    "composer/installers": "^1.9.0"
   },
   "require-dev": {
     "brain/monkey": "^2.4.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
   "require-dev": {
     "brain/monkey": "^2.4.0",
     "phpunit/phpunit": "^5.4 || ^6.0 || ^7.0",
-    "yoast/yoastcs": "^2.0.0",
+    "yoast/yoastcs": "^2.1.0",
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "php-parallel-lint/php-console-highlighter": "^0.5"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c871078df221a7b1fbe646635303936",
+    "content-hash": "933ea11205750e40ecba1b3ce8c173ac",
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.6.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b"
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/cfcca6b1b60bc4974324efb5783c13dca6932b5b",
-                "reference": "cfcca6b1b60bc4974324efb5783c13dca6932b5b",
+                "url": "https://api.github.com/repos/composer/installers/zipball/b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0"
+                "composer-plugin-api": "^1.0 || ^2.0"
             },
             "replace": {
                 "roundcube/plugin-installer": "*",
                 "shama/baton": "*"
             },
             "require-dev": {
-                "composer/composer": "1.0.*@dev",
-                "phpunit/phpunit": "^4.8.36"
+                "composer/composer": "1.6.* || 2.0.*@dev",
+                "composer/semver": "1.0.* || 2.0.*@dev",
+                "phpunit/phpunit": "^4.8.36",
+                "sebastian/comparator": "^1.2.4",
+                "symfony/process": "^2.3"
             },
             "type": "composer-plugin",
             "extra": {
@@ -65,6 +68,7 @@
                 "Kanboard",
                 "Lan Management System",
                 "MODX Evo",
+                "MantisBT",
                 "Mautic",
                 "Maya",
                 "OXID",
@@ -73,6 +77,7 @@
                 "RadPHP",
                 "SMF",
                 "Thelia",
+                "Whmcs",
                 "WolfCMS",
                 "agl",
                 "aimeos",
@@ -95,6 +100,7 @@
                 "installer",
                 "itop",
                 "joomla",
+                "known",
                 "kohana",
                 "laravel",
                 "lavalite",
@@ -117,6 +123,7 @@
                 "shopware",
                 "silverstripe",
                 "sydes",
+                "sylius",
                 "symfony",
                 "typo3",
                 "wordpress",
@@ -124,7 +131,17 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2018-08-27T06:10:37+00:00"
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-07T06:57:05+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20103c7660983cb713c74013da342dde",
+    "content-hash": "1c871078df221a7b1fbe646635303936",
     "packages": [
         {
             "name": "composer/installers",
@@ -240,22 +240,22 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.6.2",
+            "version": "v0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a"
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/8001af8eb107fbfcedc31a8b51e20b07d85b457a",
-                "reference": "8001af8eb107fbfcedc31a8b51e20b07d85b457a",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -302,7 +302,7 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2020-01-29T20:22:20+00:00"
+            "time": "2020-06-25T14:57:39+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1280,6 +1280,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-12-04T08:55:13+00:00"
         },
         {
@@ -1939,16 +1940,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -1986,7 +1987,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2204,28 +2205,28 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "2.0.2",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "0f6d2a18545e4b0751d7966a61f0cfc95a9f8d72"
+                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/0f6d2a18545e4b0751d7966a61f0cfc95a9f8d72",
-                "reference": "0f6d2a18545e4b0751d7966a61f0cfc95a9f8d72",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/8cc5cb79b950588f05a45d68c3849ccfcfef6298",
+                "reference": "8cc5cb79b950588f05a45d68c3849ccfcfef6298",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",
                 "php": ">=5.4",
                 "phpcompatibility/phpcompatibility-wp": "^2.1.0",
                 "squizlabs/php_codesniffer": "^3.5.0",
                 "wp-coding-standards/wpcs": "^2.2.0"
             },
             "require-dev": {
-                "jakub-onderka/php-console-highlighter": "^0.4",
-                "jakub-onderka/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpcompatibility/php-compatibility": "^9.2.0",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
@@ -2251,7 +2252,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2020-04-02T17:16:18+00:00"
+            "time": "2020-10-27T09:51:49+00:00"
         }
     ],
     "aliases": [],

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -38,9 +38,8 @@ class Yoast_ACF_Analysis_Assets {
 		$config = Yoast_ACF_Analysis_Facade::get_registry()->get( 'config' );
 
 		// Post page enqueue.
-		if (
-			wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit' ) ||
-			wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit-classic' )
+		if ( wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit' )
+			|| wp_script_is( WPSEO_Admin_Asset_Manager::PREFIX . 'post-edit-classic' )
 		) {
 			wp_enqueue_script(
 				'yoast-acf-analysis-post',


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updated dependencies

## Relevant technical choices:

### Composer: update YoastCS to v 2.1.0

* Updated YoastCS from `2.0.2` to `2.1.0`.
* Updated PHP_CodeSniffer from `3.5.5` to `3.5.8`.
* Updated the DealerDirect Composer plugin from `0.6.2` to `0.7.0` (which is compatible with Composer 2.0).

Relevant changes in YoastCS:
* The minimum supported WP version has changed to `5.4`.
* A new check for test doubles being named as such.
* A few bugfixes.
* Various sniffs now provide metrics.

Relevant changes in PHPCS:
* PHPCS will now _run_ without problems on PHP 8.
    Note: it will not necessarily handle all code using PHP 8 syntax correctly yet, though it does contain preliminary support for various syntaxes.
* Lots of bugfixes.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/2.1.0
* https://github.com/squizlabs/php_codesniffer/releases

### Composer: update the Composer installers dependency

Update the Composer Installers dependency from `1.6.0` to `1.9.0` to fix compatibility with Composer 2.0.

Based on the changelog, this shouldn't have any other impact.

Ref: https://github.com/composer/installers/releases

### CS: minor tweak 

## Test instructions

This PR can be tested by following these steps:

* _N/A_ Verify that the build passes

