### PR TITLE
Tests: make the testsuite compatible with PHPUnit 9 and test against PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpcs.xml
 .phpcs.xml
 .cache/phpcs.cache
 phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
     - php: 7.0
       env: PHPUNIT=1
     - php: "nightly"
+      env: PHPUNIT=1
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -43,9 +44,9 @@ before_install:
 install:
 - |
   if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
-    composer install --prefer-dist --no-interaction --ignore-platform-reqs
+    travis_retry composer update yoast/wp-test-utils --with-dependencies --no-interaction --ignore-platform-reqs
   else
-    composer install --prefer-dist --no-interaction
+    travis_retry composer install --no-interaction
   fi
 - if [[ "$CHECKJS" == "1" ]]; then yarn global add grunt-cli; fi
 - if [[ "$CHECKJS" == "1" ]]; then yarn install; fi

--- a/composer.json
+++ b/composer.json
@@ -48,11 +48,10 @@
     "composer/installers": "^1.9.0"
   },
   "require-dev": {
-    "brain/monkey": "^2.5.0",
-    "phpunit/phpunit": "^5.4 || ^6.0 || ^7.0",
     "yoast/yoastcs": "^2.1.0",
     "php-parallel-lint/php-parallel-lint": "^1.2",
-    "php-parallel-lint/php-console-highlighter": "^0.5"
+    "php-parallel-lint/php-console-highlighter": "^0.5",
+    "yoast/wp-test-utils": "^0.1.0"
   },
   "autoload": {
     "classmap": [ "inc" ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "041a87ca606c16d54b79ab40be40b875",
+    "content-hash": "f1fa17f7f0df5533ee39559094429bb9",
     "packages": [
         {
             "name": "composer/installers",
@@ -987,38 +987,38 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1046,7 +1046,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2006,16 +2006,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.12.0",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/aed596913b70fae57be53d86faa2e9ef85a2297b",
+                "reference": "aed596913b70fae57be53d86faa2e9ef85a2297b",
                 "shasum": ""
             },
             "require": {
@@ -2027,7 +2027,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-main": "1.19-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2060,20 +2064,34 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T09:01:57+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.27",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996"
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/212a27b731e5bfb735679d1ffaac82bd6a1dc996",
-                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/88289caa3c166321883f67fe5130188ebbb47094",
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094",
                 "shasum": ""
             },
             "require": {
@@ -2090,11 +2108,6 @@
                 "symfony/console": "For validating YAML files using the lint command"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
@@ -2119,36 +2132,48 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-03-25T07:48:46+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
+                "php": "^5.3.3 || ^7.0 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -2170,7 +2195,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2217,6 +2242,127 @@
                 "wordpress"
             ],
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "cf3da76ae146f28050a7c4c879634c8b4c26d3d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/cf3da76ae146f28050a7c4c879634c8b4c26d3d7",
+                "reference": "cf3da76ae146f28050a7c4c879634c8b4c26d3d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "time": "2020-10-26T10:59:22+00:00"
+        },
+        {
+            "name": "yoast/wp-test-utils",
+            "version": "0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/wp-test-utils.git",
+                "reference": "e918d919800175f0a2489ed1631844831653836b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/e918d919800175f0a2489ed1631844831653836b",
+                "reference": "e918d919800175f0a2489ed1631844831653836b",
+                "shasum": ""
+            },
+            "require": {
+                "brain/monkey": "^2.5.0",
+                "php": ">=5.6",
+                "yoast/phpunit-polyfills": "^0.1.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "yoast/yoastcs": "^2.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/wp-test-utils/graphs/contributors"
+                }
+            ],
+            "description": "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
+            "homepage": "https://github.com/Yoast/wp-test-utils/",
+            "keywords": [
+                "brainmonkey",
+                "integration-testing",
+                "phpunit",
+                "unit-testing",
+                "wordpress"
+            ],
+            "time": "2020-11-13T12:03:02+00:00"
         },
         {
             "name": "yoast/yoastcs",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,21 +3,22 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.5/phpunit.xsd"
 		backupGlobals="false"
-		beStrictAboutCoversAnnotation="true"
 		beStrictAboutOutputDuringTests="true"
 		beStrictAboutTestsThatDoNotTestAnything="true"
 		beStrictAboutTodoAnnotatedTests="true"
 		bootstrap="vendor/autoload.php"
+		forceCoversAnnotation="true"
 		verbose="true"
 	>
 	<testsuites>
-		<testsuite name="unit">
+		<testsuite name="yoastacf">
 			<directory suffix="test.php">tests/php/unit</directory>
 		</testsuite>
 	</testsuites>
 
 	<filter>
-		<whitelist>
+		<whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
+			<file>yoast-acf-analysis.php</file>
 			<directory suffix=".php">inc/</directory>
 		</whitelist>
 	</filter>

--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -2,10 +2,9 @@
 
 namespace Yoast\WP\ACF\Tests\Configuration;
 
-use Brain\Monkey;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
-use PHPUnit\Framework\TestCase;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
 use Yoast_ACF_Analysis_Configuration;
 use Yoast_ACF_Analysis_Facade;
 use Yoast_ACF_Analysis_String_Store;
@@ -16,26 +15,6 @@ use Yoast_ACF_Analysis_String_Store;
  * @covers Yoast_ACF_Analysis_Configuration
  */
 class Configuration_Test extends TestCase {
-
-	/**
-	 * Sets up test fixtures.
-	 *
-	 * @return void
-	 */
-	protected function setUp() {
-		parent::setUp();
-		Monkey\setUp();
-	}
-
-	/**
-	 * Tears down test fixtures previously setup.
-	 *
-	 * @return void
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
-	}
 
 	/**
 	 * Tests empty configurations.

--- a/tests/php/unit/Configuration/string-store-test.php
+++ b/tests/php/unit/Configuration/string-store-test.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\ACF\Tests\Configuration;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Yoast_ACF_Analysis_String_Store;
 
 /**

--- a/tests/php/unit/Configuration/string-store-test.php
+++ b/tests/php/unit/Configuration/string-store-test.php
@@ -30,7 +30,7 @@ class String_Store_Test extends TestCase {
 		$store  = $this->getStore();
 		$result = $store->to_array();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assertIsArray( $result );
 		$this->assertEmpty( $result );
 	}
 
@@ -112,7 +112,7 @@ class String_Store_Test extends TestCase {
 
 		$result = $store->to_array();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assertIsArray( $result );
 		$this->assertEmpty( $result );
 	}
 
@@ -141,7 +141,7 @@ class String_Store_Test extends TestCase {
 
 		$result = $store->to_array();
 
-		$this->assertInternalType( 'array', $result );
+		$this->assertIsArray( $result );
 		$this->assertEmpty( $result );
 	}
 

--- a/tests/php/unit/Dependencies/acf-dependency-test.php
+++ b/tests/php/unit/Dependencies/acf-dependency-test.php
@@ -2,8 +2,7 @@
 
 namespace Yoast\WP\ACF\Tests\Dependencies;
 
-use Brain\Monkey;
-use PHPUnit\Framework\TestCase;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
 use Yoast_ACF_Analysis_Dependency_ACF;
 
 /**
@@ -12,26 +11,6 @@ use Yoast_ACF_Analysis_Dependency_ACF;
  * @covers Yoast_ACF_Analysis_Dependency_ACF
  */
 class ACF_Dependency_Test extends TestCase {
-
-	/**
-	 * Sets up test fixtures.
-	 *
-	 * @return void
-	 */
-	protected function setUp() {
-		parent::setUp();
-		Monkey\setUp();
-	}
-
-	/**
-	 * Tears down test fixtures previously setup.
-	 *
-	 * @return void
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
-	}
 
 	/**
 	 * Tests the situation where no ACF class exists.

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -2,8 +2,7 @@
 
 namespace Yoast\WP\ACF\Tests\Dependencies;
 
-use Brain\Monkey;
-use PHPUnit\Framework\TestCase;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
 use Yoast_ACF_Analysis_Dependency_Yoast_SEO;
 
 /**
@@ -26,26 +25,6 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @var bool
 	 */
 	protected $runTestInSeparateProcess = true;
-
-	/**
-	 * Sets up test fixtures.
-	 *
-	 * @return void
-	 */
-	protected function setUp() {
-		parent::setUp();
-		Monkey\setUp();
-	}
-
-	/**
-	 * Tears down test fixtures previously setup.
-	 *
-	 * @return void
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
-	}
 
 	/**
 	 * Tests that requirements are not met when Yoast SEO can't be found.

--- a/tests/php/unit/assets-test.php
+++ b/tests/php/unit/assets-test.php
@@ -2,9 +2,8 @@
 
 namespace Yoast\WP\ACF\Tests;
 
-use Brain\Monkey;
 use Brain\Monkey\Functions;
-use PHPUnit\Framework\TestCase;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
 use Yoast_ACF_Analysis_Assets;
 
 /**
@@ -27,26 +26,6 @@ class Assets_Test extends TestCase {
 	 * @var bool
 	 */
 	protected $runTestInSeparateProcess = true;
-
-	/**
-	 * Sets up test fixtures.
-	 *
-	 * @return void
-	 */
-	protected function setUp() {
-		parent::setUp();
-		Monkey\setUp();
-	}
-
-	/**
-	 * Tears down test fixtures previously setup.
-	 *
-	 * @return void
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
-	}
 
 	/**
 	 * Test the init hook and determines whether the proper assets are loaded.

--- a/tests/php/unit/main-test.php
+++ b/tests/php/unit/main-test.php
@@ -3,8 +3,7 @@
 namespace Yoast\WP\ACF\Tests;
 
 use AC_Yoast_SEO_ACF_Content_Analysis;
-use Brain\Monkey;
-use PHPUnit\Framework\TestCase;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
 use Yoast_ACF_Analysis_Configuration;
 use Yoast_ACF_Analysis_Facade;
 
@@ -12,26 +11,6 @@ use Yoast_ACF_Analysis_Facade;
  * Class Main_Test.
  */
 class Main_Test extends TestCase {
-
-	/**
-	 * Sets up test fixtures.
-	 *
-	 * @return void
-	 */
-	protected function setUp() {
-		parent::setUp();
-		Monkey\setUp();
-	}
-
-	/**
-	 * Tears down test fixtures previously setup.
-	 *
-	 * @return void
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
-	}
 
 	/**
 	 * Tests invalid configurations.

--- a/tests/php/unit/registry-test.php
+++ b/tests/php/unit/registry-test.php
@@ -2,7 +2,7 @@
 
 namespace Yoast\WP\ACF\Tests;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 use Yoast_ACF_Analysis_Configuration;
 use Yoast_ACF_Analysis_Facade;
 use Yoast_ACF_Analysis_Registry;

--- a/tests/php/unit/requirements-test.php
+++ b/tests/php/unit/requirements-test.php
@@ -2,11 +2,10 @@
 
 namespace Yoast\WP\ACF\Tests;
 
-use Brain\Monkey;
 use Brain\Monkey\Functions;
-use PHPUnit\Framework\TestCase;
 use Yoast\WP\ACF\Tests\Doubles\Failing_Dependency;
 use Yoast\WP\ACF\Tests\Doubles\Passing_Dependency;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
 use Yoast_ACF_Analysis_Requirements;
 
 /**
@@ -17,19 +16,10 @@ class Requirements_Test extends TestCase {
 	/**
 	 * Sets up test fixtures.
 	 */
-	protected function setUp() {
-		parent::setUp();
-		Monkey\setUp();
+	protected function set_up() {
+		parent::set_up();
 
 		Functions\expect( 'current_user_can' )->andReturn( true );
-	}
-
-	/**
-	 * Tears down test fixtures previously set up.
-	 */
-	protected function tearDown() {
-		Monkey\tearDown();
-		parent::tearDown();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Preparation for compatibility with PHP 8

## Relevant technical choices:

Replaces earlier PR #278

### Composer: require Yoast/wp-test-utils

* Adds a dev dependency to the `yoast/wp-test-utils` package, which will also make the PHPUnit Polyfills available.
* As that package already requires and manages the installable versions for BrainMonkey and PHPUnit, remove these as explicit requirements from `require-dev` in favour of letting the WP Test Utils package manage the versions.

The install is done based on PHP 5.6 and includes updating the dependencies from PHPUnit itself within the constraints of maintaining compatibility with PHP 5.6.

This new package adds the following features:
* Polyfills for various PHPUnit cross-version changes.
* Basic test cases for use by the plugins.

Refs:
* https://github.com/Yoast/wp-test-utils
* https://github.com/Yoast/PHPUnit-Polyfills/

### Tests: selectively switch over to the Yoast\WPTestUtils\BrainMonkey\TestCase

Not all test classes in the ACF testsuite are based on BrainMonkey and those that are generally just set up the BrainMonkey native stubs and don't add the other stubs commonly used by Yoast plugins.

With that in mind:
* Selectively switch out the parent test class `PHPUnit\Framework\TestCase` to use `Yoast\WPTestUtils\BrainMonkey\TestCase` instead.
* Remove redundant `setUp()` and `tearDown()` methods which are now handled in the `Yoast\WPTestUtils\BrainMonkey\TestCase` instead.
* In the one case where the `setUp()` added an extra stub, rename the method to `set_up()` for cross-version compatibility based on the PHPUnit Polyfills.

### Tests: selectively switch over to the Yoast\PHPUnitPolyfills\TestCases\TestCase

For those test classes in the ACF testsuite which are not based on BrainMonkey, we don't need the overhead of loading the BrainMonkey framework, but do want the PHPUnit cross-version compatibility.

So, the `use` statements referring to the PHPUnit native `PHPUnit\Framework\TestCase` have been replaced with `use` statements for the PHPUnit cross-version compatible `Yoast\PHPUnitPolyfills\TestCases\TestCase`.

### Tests: modernize used assertions

The PHPUnit Polyfills allows for using PHPUnit 9.x assertions, even when the tests are being run on older PHPUnit versions.

This updates select assertions to the modern PHPUnit syntax, most notably, it switches out the following assertions:
* `assertInternalType()` to `assertIs[Type]()`.

### Travis: run the tests against PHP 8/nightly

Now the tests are fully compatible with PHPUnit 9, the test suite can be run on PHP 8.

To that end, we run a `composer update` for just and only the test dependencies on PHP 8 to make sure that the test dependencies available are compatible with PHP 8.
And as the `composer.json` contains a hard-coded `platform.php` setting, we use `ignore-platform-reqs`  to get round that setting.

Includes:
* Adding `travis_retry` to `composer install`-like commands to get round builds stalling on the connection with Packagist, especially on older PHP versions.
* Removing `--prefer-dist` from the `composer install` command as that is the default, so doesn't need to be explicitly passed.

### PHPUnit config: minor tweaks

* Rename the testsuite to use a more descriptive name.
* Improve the code coverage configuration:
    - Allow for code coverage to record coverage of code in the `yoast-acf-analysis.php` file.
    - Add `addUncoveredFilesFromWhitelist` and `processUncoveredFilesFromWhitelist` directives with sensible values.
    - Remove the `beStrictAboutCoversAnnotation` attribute to not mark tests which touch code not mentioned in `@covers` or `@uses` tags as "risky".
    - Add the `forceCoversAnnotation` attribute to only record code coverage for the method under test as annotated via a `@covers` annotation.

Based on this configuration, the strict code coverage for this testsuite is currently **51.76%**.

## Test instructions

This PR can be tested by following these steps:

* Verify the output of all builds for this PR, making sure that 1) the installation via Composer works without issues, 2) the tests are being run and 3) the tests pass.

To test locally, it will be simplest to:
1. Run `composer install`.
2. Run `composer test` on any PHP version below 8.0 and see the tests pass, including a more accurate assertion count (72 compared to 52 previously, due to Mockery expectations now being counted).
    This confirms that the changes to the `TestCase` and the assertion update to use PHPUnit 9.x syntax works correctly cross-version as the PHPUnit version installed based on the `composer.lock` file will be PHPUnit 5.7.27.
3. Switch to PHP 8.
4. Run `composer update yoast/wp-test-utils --with-dependencies --ignore-platform-reqs`
5. Run `composer test` to see the tests running and passing on PHP 8 in combination with PHPUnit 9.x.
    This confirms that the tests can now run cross-version on all PHPUnit versions between PHPUnit 5.7 and PHPUnit 9.x and that the tests run and pass on PHP 8.

Note: this doesn't confirm full PHP 8 compatibility yet as the test code coverage as noted above is only ~50%.
