### PR TITLE
Update WP Test Utils, BrainMonkey and add PHP 8.0 to the Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,9 @@ jobs:
       env: PHPUNIT=1
     - php: 7.0
       env: PHPUNIT=1
-    - php: "nightly"
+    - php: 8.0
       env: PHPUNIT=1
+    - php: "nightly"
 
   allow_failures:
     # Allow failures for unstable builds.
@@ -43,7 +44,7 @@ before_install:
 
 install:
 - |
-  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+  if [[ ${TRAVIS_PHP_VERSION:0:1} == "8" || $TRAVIS_PHP_VERSION == "nightly" ]]; then
     travis_retry composer update yoast/wp-test-utils --with-dependencies --no-interaction --ignore-platform-reqs
   else
     travis_retry composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "yoast/yoastcs": "^2.1.0",
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "php-parallel-lint/php-console-highlighter": "^0.5",
-    "yoast/wp-test-utils": "^0.1.0"
+    "yoast/wp-test-utils": "^0.2.1"
   },
   "autoload": {
     "classmap": [ "inc" ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1fa17f7f0df5533ee39559094429bb9",
+    "content-hash": "a752bdae5fe3aad0aa6ded7fe8496050",
     "packages": [
         {
             "name": "composer/installers",
@@ -2310,20 +2310,20 @@
         },
         {
             "name": "yoast/wp-test-utils",
-            "version": "0.1.1",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/wp-test-utils.git",
-                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942"
+                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/206df89cfefe4d2cbdf354e4a6212869de8bd942",
-                "reference": "206df89cfefe4d2cbdf354e4a6212869de8bd942",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/c5cdabd58f2aa6f2a93f734cf48125f880c90101",
+                "reference": "c5cdabd58f2aa6f2a93f734cf48125f880c90101",
                 "shasum": ""
             },
             "require": {
-                "brain/monkey": "^2.5.0",
+                "brain/monkey": "^2.6.0",
                 "php": ">=5.6",
                 "yoast/phpunit-polyfills": "^0.2.0"
             },
@@ -2368,7 +2368,7 @@
                 "unit-testing",
                 "wordpress"
             ],
-            "time": "2020-11-25T12:40:18+00:00"
+            "time": "2020-12-09T15:26:02+00:00"
         },
         {
             "name": "yoast/yoastcs",


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Update CI/test environment

## Relevant technical choices:

### Composer: update test tools

Update WP Test Utils to version 0.2.1 with dependencies, ~~which means that BrainMonkey and PHPUnit Polyfills have now also been updated~~.

Refs:
* https://github.com/Yoast/wp-test-utils/releases/tag/0.2.0
* https://github.com/Yoast/wp-test-utils/releases/tag/0.2.1

### Travis: run the tests against PHP 8.0

Since this Friday, Travis now has a PHP 8.0 image available.

This commit:
* Adds a new build against PHP 8.0, with `PHPUNIT` flag set to `1` (= on), which is not allowed to fail.
* No longer run the tests against `nightly` (PHP 8.1), only lint the code on `nightly`.
* In the `install` section: makes sure that the `composer install` with `--ignore-platform-reqs` is used for PHP 8.x as otherwise the install would fail due to PHPUnit 5.x (as per the lock file) not being allowed to be installed on PHP 8.



## Test instructions

This PR can be tested by following these steps:

* If the Travis build passes, we're good.
