### PR TITLE
QAK-2538 hotfix error on term pages

### DIFF
--- a/js/src/main.js
+++ b/js/src/main.js
@@ -4,7 +4,9 @@
 var App = require( "./app.js" );
 
 wp.domReady( function() {
-	if ( "undefined" !== typeof YoastSEO ) {
-		YoastACFAnalysis = new App();
-	}
+	jQuery( document ).ready( function() {
+		if ( "undefined" !== typeof YoastSEO ) {
+			YoastACFAnalysis = new App();
+		}
+	} );
 } );

--- a/js/src/main.js
+++ b/js/src/main.js
@@ -1,12 +1,23 @@
 /* global jQuery, YoastSEO, wp, YoastACFAnalysis: true */
 /* exported YoastACFAnalysis */
 
-var App = require( "./app.js" );
+const App = require( "./app.js" );
+
+/**
+ * Initializes the YoastACFAnalysis app.
+ *
+ * @returns {void}
+ */
+function initializeYoastACFAnalysis() {
+	YoastACFAnalysis = new App();
+}
 
 wp.domReady( function() {
-	jQuery( document ).ready( function() {
-		if ( "undefined" !== typeof YoastSEO ) {
-			YoastACFAnalysis = new App();
-		}
-	} );
+	if ( ! ( YoastSEO && YoastSEO.app ) ) {
+		// Give it one more attempt in 100ms.
+		setTimeout( initializeYoastACFAnalysis, 100 );
+		return;
+	}
+
+	initializeYoastACFAnalysis();
 } );

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -398,12 +398,25 @@ module.exports = {
 /* global jQuery, YoastSEO, wp, YoastACFAnalysis: true */
 /* exported YoastACFAnalysis */
 
-var App = require( "./app.js" );
+const App = require( "./app.js" );
+
+/**
+ * Initializes the YoastACFAnalysis app.
+ *
+ * @returns {void}
+ */
+function initializeYoastACFAnalysis() {
+	YoastACFAnalysis = new App();
+}
 
 wp.domReady( function() {
-	if ( "undefined" !== typeof YoastSEO ) {
-		YoastACFAnalysis = new App();
+	if ( ! ( YoastSEO && YoastSEO.app ) ) {
+		// Give it one more attempt in 100ms.
+		setTimeout( initializeYoastACFAnalysis, 100 );
+		return;
 	}
+
+	initializeYoastACFAnalysis();
 } );
 
 },{"./app.js":1}],9:[function(require,module,exports){


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where ACF Analysis would fail on term pages.

## Relevant technical choices:

* This is a load order problem. In the `term-scraper` of Yoast SEO we still use `jQuery( document ).ready`. 100ms should be enough to run after the term-scraper initialization. Alternatively we could remove jQuery ready there. Resulting in both "only" using WP's `domReady`, which would work too.

## Test instructions

This PR can be tested by following these steps:

1. Install and activate the following plugins on WordPress 5.6: Yoast SEO 15.4, ACF Content Analysis for Yoast SEO 3.0 and Advanced Custom Fields 5.9.3
2. Configure ACF to show a custom text field on taxonomy forms (see screenshot in issue)
3. Open the browser console and visit a taxonomy edit page
4. Notice the error is no longer in the console.

Fixes https://yoast.atlassian.net/browse/QAK-2538
