### PR TITLE
Travis: remove nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,6 @@ jobs:
       env: PHPUNIT=1
     - php: 8.0
       env: PHPUNIT=1
-    - php: "nightly"
-
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: "nightly"
 
 before_install:
 - export SECURITYCHECK_DIR=/tmp/security-checker


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Updates CI

## Relevant technical choices:

At this time, the current PHP 8.0 version is `8.0.11`. The Travis PHP `8.0` image yields PHP `8.0.9`, which is good enough for PHP 8.0.

`nightly` however is PHP `8.0.3` and hasn't been updated since Feb 2021, so running tests against that image is completely useless at this time.

Notes:
    * Tested `nightly` against all relevant `dist`s - `xenial`, `bionic` and `focal` and none have a more current image.
    * The [PHP Build project](https://github.com/php-build/php-build/tree/master/share/php-build/definitions), which Travis pulls its images from, _does_ have a PHP `8.1snapshot` image available.
        I've tested to see if that image is available on Travis, but unfortunately, no luck there either.

## Test instructions

This PR can be tested by following these steps:

* _N/A_ If the build passes, we're good.
