### PR TITLE
Composer: allow the PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,10 @@
   "config": {
     "platform": {
       "php": "5.6.40"
+    },
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "composer/installers": true
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Composer 2.2. compatibility

## Relevant technical choices:

The `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is used to register external PHPCS standards with PHPCS.
The `composer/installers` Composer plugin is used to install the plugin in the correct directory in a WordPress context.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run. This adds the necessary configuration for that.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution
