### PR TITLE
GH Actions: minor tweaks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -39,7 +39,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       # Check the codestyle of the files.
       # The results of the CS check will be shown inline in the PR via the CS2PR tool.

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v2
 
       # The ubuntu images come with Node, npm and yarn pre-installed.
-      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
 
       # This action also handles the caching of the Yarn dependencies.
       # https://github.com/actions/setup-node

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -29,14 +29,14 @@ jobs:
         uses: actions/checkout@v2
 
       # The ubuntu images come with Node, npm and yarn pre-installed.
-      # For Ubuntu 20, this means Node 14 will be used.
       # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
 
-      # Using this action to handle the caching of the Yarn dependencies.
+      # This action also handles the caching of the Yarn dependencies.
       # https://github.com/actions/setup-node
-      - name: Set up node to cache dependencies
+      - name: Set up node and enable caching of dependencies
         uses: actions/setup-node@v2
         with:
+          node-version: '14'
           cache: 'yarn'
 
       - name: Yarn install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
     name: "Lint: PHP ${{ matrix.php_version }}"
 
     # Allow builds to fail on as-of-yet unreleased PHP versions.
-    continue-on-error: ${{ matrix.php_version == '8.1' || matrix.php_version == '8.2' }}
+    continue-on-error: ${{ matrix.php_version == '8.2' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Lint against parse errors
         run: composer lint -- --checkstyle | cs2pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,11 @@ jobs:
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies (PHP < 7.3)
         if: ${{ matrix.php_version < '7.3' }}
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Install Composer dependencies (PHP 7.3+)
         if: ${{ matrix.php_version >= '7.3' }}
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           # Force a `composer update` run.
           dependency-versions: "highest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
 
     name: "Unit Test: PHP ${{ matrix.php_version }}"
 
-    # Allow builds to fail on as-of-yet unreleased PHP versions.
-    continue-on-error: ${{ matrix.php_version == '8.1' }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         php_version: ['5.6', '7.0', '7.4', '8.0', '8.1']
 
-    name: "Test: PHP ${{ matrix.php_version }}"
+    name: "Unit Test: PHP ${{ matrix.php_version }}"
 
     # Allow builds to fail on as-of-yet unreleased PHP versions.
     continue-on-error: ${{ matrix.php_version == '8.1' }}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improve CI

## Relevant technical choices:

### GH Actions: minor build name clarification

### GH Actions: fix the Node version to Node 14

### GH Actions: PHP 8.1 has been released

... so builds against PHP 8.1 should no longer be allowed to fail.

### GH Actions: version update for ramsey/composer-install

The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Refs:
* https://github.com/ramsey/composer-install/releases/

### GH Actions: fix broken link 

(used in inline script documentation) 

## Test instructions

This PR can be tested by following these steps:

* _N/A_ If the build passes, we're good.
