### PR TITLE
GH Actions: update setup-node action runner

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -34,7 +34,7 @@ jobs:
       # This action also handles the caching of the Yarn dependencies.
       # https://github.com/actions/setup-node
       - name: Set up node and enable caching of dependencies
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
           cache: 'yarn'


### PR DESCRIPTION

## Summary
This PR can be summarized in the following changelog entry:

* Update CI

## Relevant technical choices:

The `setup-node` action has released a new major.
This upgrades the JS workflow to use this new action runner.

Ref: https://github.com/actions/setup-node/releases/tag/v3.0.0

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes (and the deploy after the merge succeeds), we're good.


