### PR TITLE
Composer: update YoastCS and dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     "composer/installers": "^1.12.0"
   },
   "require-dev": {
-    "yoast/yoastcs": "^2.2.1",
+    "yoast/yoastcs": "^2.3.0",
     "yoast/wp-test-utils": "^1.1.1"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5af1942260c67236534d6b0b730a1b55",
+    "content-hash": "889305f8fb02e6fcdbc361d47d8f3cfe",
     "packages": [
         {
             "name": "composer/installers",
@@ -279,35 +279,38 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
+                "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -323,7 +326,7 @@
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -347,10 +350,10 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "time": "2023-01-05T11:28:13+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2560,30 +2563,30 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "a078d536ba3b695e77cef7c98b4b7f4aa257ba30"
+                "reference": "b52b3f1f08e303d3c261bc522a36b2b63618fea5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/a078d536ba3b695e77cef7c98b4b7f4aa257ba30",
-                "reference": "a078d536ba3b695e77cef7c98b4b7f4aa257ba30",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/b52b3f1f08e303d3c261bc522a36b2b63618fea5",
+                "reference": "b52b3f1f08e303d3c261bc522a36b2b63618fea5",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6.2 || ^0.7",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcompatibility/phpcompatibility-wp": "^2.1.3",
-                "squizlabs/php_codesniffer": "^3.6.2",
+                "phpcompatibility/phpcompatibility-wp": "^2.1.4",
+                "squizlabs/php_codesniffer": "^3.7.1",
                 "wp-coding-standards/wpcs": "^2.3.0"
             },
             "require-dev": {
                 "phpcompatibility/php-compatibility": "^9.3.5",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "roave/security-advisories": "dev-master"
             },
@@ -2604,6 +2607,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress",
                 "yoast"
             ],
@@ -2611,7 +2615,7 @@
                 "issues": "https://github.com/Yoast/yoastcs/issues",
                 "source": "https://github.com/Yoast/yoastcs"
             },
-            "time": "2022-02-22T12:53:14+00:00"
+            "time": "2023-01-09T11:26:18+00:00"
         }
     ],
     "aliases": [],
@@ -2626,5 +2630,5 @@
     "platform-overrides": {
         "php": "5.6.40"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Update dev dependencies

## Relevant technical choices:

* YoastCS 2.3.0 has been released. Previous version used was `2.2.1`.
    Ref: https://github.com/Yoast/yoastcs/releases/tag/2.3.0
* Version 1.0.0 of the Composer PHPCS plugin has been released. Previous version used was `0.7.2`.
    Ref: https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build passes, we're good.