### PR TITLE
Custom fields like URL & email are used for analysis which doesn't make sense#19690

### DIFF
--- a/inc/ac-yoast-seo-acf-content-analysis.php
+++ b/inc/ac-yoast-seo-acf-content-analysis.php
@@ -243,7 +243,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 			'group',
 
 			'url',
-			'email'
+			'email',
 		];
 
 		foreach ( $default_blacklist as $type ) {


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the analysis by excluding content from the URL and email fields.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Create Custom Field Group
* Add url and email field to the group
* Create new post and put the following text "This is text post in the editor to check advanced custom fields."
* Open Readability tab
* Change url or email field value. For example add as value "Even as it is I have not been defeated by this bastard."
* Readability score should not be changed.

Fixes [#19690](https://github.com/Yoast/wordpress-seo/issues/19690)
