### PR TITLE
Dependabot: add reviewer config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     labels:
       - "changelog: non-user-facing"
       - "yoast cs/qa"
+    reviewers:
+      - "jrfnl"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Ensure that dependabot PRs get reviewed/merged.

## Relevant technical choices:

The Dependabot PRs can have a tendency to stay open for a long time, while for the GH Actions related ones I keep an eye on all used action runner releases anyway.

However, I don't "watch" all Yoast repos, so adding this configuration will ensure that I get notified about Dependabot PRs related to GH Actions action runners for this repo (and can merge it if appropriate).


## Test instructions

This PR can be tested by following these steps:

* N/A_