### PR TITLE
CS/QA: fix incorrect parameter order in test assertions

### DIFF
--- a/tests/php/unit/Configuration/configuration-test.php
+++ b/tests/php/unit/Configuration/configuration-test.php
@@ -44,7 +44,7 @@ class Configuration_Test extends TestCase {
 			$configuration->to_array()
 		);
 
-		$this->assertSame( Filters\applied( 'acf/get_info' ), 1 );
+		$this->assertSame( 1, Filters\applied( 'acf/get_info' ) );
 	}
 
 	/**
@@ -159,7 +159,7 @@ class Configuration_Test extends TestCase {
 			->with( [] )
 			->andReturn( [] );
 
-		$this->assertSame( $configuration->get_blacklist_name(), $blacklist_name );
+		$this->assertSame( $blacklist_name, $configuration->get_blacklist_name() );
 
 
 		Filters\expectApplied( 'ysacf_exclude_fields' )
@@ -167,7 +167,7 @@ class Configuration_Test extends TestCase {
 			->with( [] )
 			->andReturn( [] );
 
-		$this->assertSame( $configuration->get_blacklist_name()->to_array(), [] );
+		$this->assertSame( [], $configuration->get_blacklist_name()->to_array() );
 
 
 		Filters\expectApplied( 'ysacf_exclude_fields' )
@@ -175,7 +175,7 @@ class Configuration_Test extends TestCase {
 			->with( [] )
 			->andReturn( [ 'some_field_name' ] );
 
-		$this->assertSame( $configuration->get_blacklist_name()->to_array(), [ 'some_field_name' ] );
+		$this->assertSame( [ 'some_field_name' ], $configuration->get_blacklist_name()->to_array() );
 	}
 
 	/**
@@ -198,14 +198,14 @@ class Configuration_Test extends TestCase {
 			->with( [] )
 			->andReturn( 'invalid' );
 
-		$this->assertSame( $configuration->get_blacklist_name(), $blacklist_name );
+		$this->assertSame( $blacklist_name, $configuration->get_blacklist_name() );
 
 		Filters\expectApplied( 'ysacf_exclude_fields' )
 			->once()
 			->with( [] )
 			->andReturn( 'invalid' );
 
-		$this->assertSame( $configuration->get_blacklist_name()->to_array(), [] );
+		$this->assertSame( [], $configuration->get_blacklist_name()->to_array() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Test improvements

## Relevant technical choices:

Fix incorrect parameter order in test assertions, which makes debugging harder.

The first parameter for `assertSame()` is the `$expected` value, the second should be the _actual_ value, like retrieved via a function call.


## Test instructions

This PR can be tested by following these steps:

* _N/A_ If the tests pass, we're good.
