### PR TITLE
Fix required version numbers

### DIFF
--- a/inc/dependencies/dependency-acf.php
+++ b/inc/dependencies/dependency-acf.php
@@ -10,6 +10,8 @@
  */
 final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Dependency {
 
+	const MINIMAL_REQUIRED_ACF_VERSION = '6.0.0';
+
 	/**
 	 * Checks if ACF is active.
 	 *
@@ -20,7 +22,7 @@ final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Depe
 			return false;
 		}
 
-		if ( defined( 'ACF_VERSION' ) && version_compare( ACF_VERSION, '5.7.0', '<' ) ) {
+		if ( defined( 'ACF_VERSION' ) && version_compare( ACF_VERSION, self::MINIMAL_REQUIRED_ACF_VERSION, '<' ) ) {
 			return false;
 		}
 
@@ -39,10 +41,11 @@ final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Depe
 	 */
 	public function message_plugin_not_activated() {
 		$message = sprintf(
-			/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO, %2$s resolves to Advanced Custom Fields */
-			__( '%1$s requires %2$s (free or pro) 5.7 or higher to be installed and activated.', 'acf-content-analysis-for-yoast-seo' ),
+			/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO, %2$s resolves to Advanced Custom Fields, %3$s resolves to the minimum required ACF version. */
+			__( '%1$s requires %2$s (free or pro) %3$s or higher to be installed and activated.', 'acf-content-analysis-for-yoast-seo' ),
 			'ACF Content Analysis for Yoast SEO',
-			'Advanced Custom Fields'
+			'Advanced Custom Fields',
+			self::MINIMAL_REQUIRED_ACF_VERSION
 		);
 
 		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );

--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -48,11 +48,10 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 	 */
 	public function message_plugin_not_activated() {
 		$message = sprintf(
-			/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO, %2$s resolves to Yoast SEO for WordPress, %3$s resolves to the minimal plugin version */
-			__( '%1$s requires %2$s %3$s (or higher) to be installed and activated.', 'acf-content-analysis-for-yoast-seo' ),
+			/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO, %2$s resolves to Yoast SEO. */
+			__( '%1$s requires %2$s to be installed and activated.', 'acf-content-analysis-for-yoast-seo' ),
 			'ACF Content Analysis for Yoast SEO',
-			'Yoast SEO for WordPress',
-			self::MINIMAL_REQUIRED_VERSION
+			'Yoast SEO'
 		);
 
 		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );
@@ -66,7 +65,7 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 			/* translators: %1$s resolves to Yoast SEO, %2$s resolves to ACF Content Analysis for Yoast SEO. */
 			__( 'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.', 'acf-content-analysis-for-yoast-seo' ),
 			'Yoast SEO',
-			'ACF Content Analysis for Yoast SEO',
+			'ACF Content Analysis for Yoast SEO'
 		);
 
 		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );

--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -10,7 +10,7 @@
  */
 final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysis_Dependency {
 
-	const MINIMAL_REQUIRED_VERSION = 14.9;
+	const MINIMAL_REQUIRED_VERSION = '20.8';
 
 	/**
 	 * Checks if this dependency is met.

--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -10,7 +10,7 @@
  */
 final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysis_Dependency {
 
-	const MINIMAL_REQUIRED_VERSION = '20.8';
+	const MINIMAL_REQUIRED_VERSION = '20.8-RC1';
 
 	/**
 	 * Checks if this dependency is met.

--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -63,11 +63,10 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 	 */
 	public function message_minimum_version() {
 		$message = sprintf(
-			/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO, %2$s resolves to Yoast SEO for WordPress, %3$s resolves to the minimal plugin version */
-			__( '%1$s requires %2$s %3$s or higher, please update the plugin.', 'acf-content-analysis-for-yoast-seo' ),
+			/* translators: %1$s resolves to Yoast SEO, %2$s resolves to ACF Content Analysis for Yoast SEO. */
+			__( 'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.', 'acf-content-analysis-for-yoast-seo' ),
+			'Yoast SEO',
 			'ACF Content Analysis for Yoast SEO',
-			'Yoast SEO for WordPress',
-			self::MINIMAL_REQUIRED_VERSION
 		);
 
 		printf( '<div class="error"><p>%s</p></div>', esc_html( $message ) );

--- a/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
+++ b/tests/php/unit/Dependencies/yoast-seo-dependency-test.php
@@ -43,7 +43,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testPass() {
-		\define( 'WPSEO_VERSION', '14.9.0' );
+		\define( 'WPSEO_VERSION', '20.8' );
 
 		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertTrue( $testee->is_met() );
@@ -55,7 +55,7 @@ class Yoast_SEO_Dependency_Test extends TestCase {
 	 * @return void
 	 */
 	public function testOldVersion() {
-		\define( 'WPSEO_VERSION', '14.5.0' );
+		\define( 'WPSEO_VERSION', '20.7' );
 
 		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertFalse( $testee->is_met() );


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the minimum required Yoast SEO version to 20.8.
* Sets the minimum required ACF version to 6.0.0.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Install with Yoast 20.8-RC* and ACF 6.* and see you don't get any notice
* Install with Yoast 20.7 and see you get a notice "Please upgrade the Yoast SEO plugin to the latest version to allow the ACF Content Analysis for Yoast SEO module to work."
* Install with ACF 5.* and see you get a notice "ACF Content Analysis for Yoast SEO requires ACF (free or pro) 6.0.0 or higher to be installed and activated."
* Install without Yoast SEO and see you get a notice "ACF Content Analysis for Yoast SEO requires Yoast SEO to be installed and activated."

Fixes #
