### PR TITLE
Tests: use PHPUnit annotations

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -101,16 +101,6 @@
 		</properties>
 	</rule>
 
-	<!-- Whitelist a few non-snakecase PHPUnit properties. -->
-	<rule ref="WordPress.NamingConventions.ValidVariableName">
-		<properties>
-			<property name="customPropertiesWhitelist" type="array">
-				<element value="preserveGlobalState"/>
-				<element value="runTestInSeparateProcess"/>
-			</property>
-		</properties>
-	</rule>
-
 
 	<!--
 	#############################################################################

--- a/tests/Unit/Assets_Test.php
+++ b/tests/Unit/Assets_Test.php
@@ -10,22 +10,11 @@ use Yoast_ACF_Analysis_Assets;
  * Class Assets_Test.
  *
  * @covers Yoast_ACF_Analysis_Assets
+ *
+ * @preserveGlobalState disabled
+ * @runTestsInSeparateProcesses
  */
 class Assets_Test extends TestCase {
-
-	/**
-	 * Whether or not to preserve the global state.
-	 *
-	 * @var bool
-	 */
-	protected $preserveGlobalState = false;
-
-	/**
-	 * Whether or not to run each test in a separate process.
-	 *
-	 * @var bool
-	 */
-	protected $runTestInSeparateProcess = true;
 
 	/**
 	 * Test the init hook and determines whether the proper assets are loaded.

--- a/tests/Unit/Dependencies/Dependency_Yoast_SEO_Test.php
+++ b/tests/Unit/Dependencies/Dependency_Yoast_SEO_Test.php
@@ -9,22 +9,10 @@ use Yoast_ACF_Analysis_Dependency_Yoast_SEO;
  * Class Dependency_Yoast_SEO_Test.
  *
  * @covers Yoast_ACF_Analysis_Dependency_Yoast_SEO
+ *
+ * @runTestsInSeparateProcesses
  */
 class Dependency_Yoast_SEO_Test extends TestCase {
-
-	/**
-	 * Whether or not to preserve the global state.
-	 *
-	 * @var bool
-	 */
-	protected $preserveGlobalState = false;
-
-	/**
-	 * Whether or not to run each test in a separate process.
-	 *
-	 * @var bool
-	 */
-	protected $runTestInSeparateProcess = true;
 
 	/**
 	 * Tests that requirements are not met when Yoast SEO can't be found.


### PR DESCRIPTION

## Summary

This PR can be summarized in the following changelog entry:

* Test tweak

## Relevant technical choices:

Use PHPUnit annotations instead of properties.

Apparently this must have worked in some way, but the `preserveGlobalState` for the `DependencyYoastSEOTest` was definitely not correct (and probably not working either).


## Test instructions

This PR can be tested by following these steps:

* _N/A_ If the builds pass, we're good.