### PR TITLE
Composer: remove redundant CLI argument from scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,10 +78,10 @@
 			"@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude node_modules --exclude .git"
 		],
 		"test": [
-			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage --colors=always"
+			"@php ./vendor/phpunit/phpunit/phpunit --no-coverage"
 		],
 		"coverage": [
-			"@php ./vendor/phpunit/phpunit/phpunit --colors=always"
+			"@php ./vendor/phpunit/phpunit/phpunit"
 		],
 		"check-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* QA

## Relevant technical choices:

CLI arguments should either be encoded in the config file or set by the dev-user. This is neither here nor there.

## Test instructions

This PR can be tested by following these steps:

* _N/A_
