### PR TITLE
Prevent repeated XHR calls with `query-attachments` action

### DIFF
--- a/js/src/cache/cache.js
+++ b/js/src/cache/cache.js
@@ -33,7 +33,7 @@ Cache.prototype.getUncached =  function( ids, store ) {
 	ids = _.uniq( ids );
 
 	return ids.filter( function( id ) {
-		var value = id === '' ? true : that.get( id, store );
+		var value = id === "" ? true : that.get( id, store );
 
 		return value === false;
 	} );

--- a/js/src/cache/cache.js
+++ b/js/src/cache/cache.js
@@ -33,7 +33,7 @@ Cache.prototype.getUncached =  function( ids, store ) {
 	ids = _.uniq( ids );
 
 	return ids.filter( function( id ) {
-		var value = that.get( id, store );
+		var value = id === '' ? true : that.get( id, store );
 
 		return value === false;
 	} );

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -180,7 +180,7 @@ Cache.prototype.getUncached =  function( ids, store ) {
 	ids = _.uniq( ids );
 
 	return ids.filter( function( id ) {
-		var value = that.get( id, store );
+		var value = id === '' ? true : that.get( id, store );
 
 		return value === false;
 	} );

--- a/js/yoast-acf-analysis.js
+++ b/js/yoast-acf-analysis.js
@@ -180,7 +180,7 @@ Cache.prototype.getUncached =  function( ids, store ) {
 	ids = _.uniq( ids );
 
 	return ids.filter( function( id ) {
-		var value = id === '' ? true : that.get( id, store );
+		var value = id === "" ? true : that.get( id, store );
 
 		return value === false;
 	} );


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where browser performance was degraded by useless AJAX calls with an image or gallery field. Props to [mmorris8](https://github.com/mmorris8).

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Install and activate Free, ACF and this plugin
* create a new field group attached to posts
* add an image field and save the field group
* edit a post
* add an image in the image field
* keep the network tab open in the browser dev tools/inspector
* check the XHR calls
* **without this patch:**
  * you should see a repeated call to `admin-ajax.php` with this data as request content: 
```
query[post__in][]: ""
action: "query-attachments"
```
* **with this patch:**
  * you should not see a repeated call to `admin-ajax.php` with this data as request content: 
* **Note**: you may still see a repeated `admin-ajax.php` but with `action: "heartbeat"` - this is expected, and should happen much more rarely than the other call.
* Check that the analysis still work, e.g. add a focus keyphrase and see the analysis complains since it's not in the image ALT text, add the keyphrase there and see the analysis acknowledges this
  

Fixes #

Original PR: https://github.com/mmorris8/yoast-acf-analysis/pull/1
