### PR TITLE
Sets the minimum required Yoast SEO version to 24.6

### DIFF
--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -10,7 +10,7 @@
  */
 final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysis_Dependency {
 
-	public const MINIMAL_REQUIRED_VERSION = '20.8-RC1';
+	public const MINIMAL_REQUIRED_VERSION = '24.6-RC1';
 
 	/**
 	 * Checks if this dependency is met.

--- a/tests/Unit/Dependencies/Dependency_Yoast_SEO_Test.php
+++ b/tests/Unit/Dependencies/Dependency_Yoast_SEO_Test.php
@@ -31,7 +31,7 @@ final class Dependency_Yoast_SEO_Test extends TestCase {
 	 * @return void
 	 */
 	public function testPass() {
-		\define( 'WPSEO_VERSION', '20.8' );
+		\define( 'WPSEO_VERSION', '24.6' );
 
 		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertTrue( $testee->is_met() );
@@ -43,7 +43,7 @@ final class Dependency_Yoast_SEO_Test extends TestCase {
 	 * @return void
 	 */
 	public function testOldVersion() {
-		\define( 'WPSEO_VERSION', '20.7' );
+		\define( 'WPSEO_VERSION', '24.5' );
 
 		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$this->assertFalse( $testee->is_met() );
@@ -67,7 +67,7 @@ final class Dependency_Yoast_SEO_Test extends TestCase {
 	 * @return void
 	 */
 	public function testAdminNoticeMinimumVersion() {
-		\define( 'WPSEO_VERSION', '2.0.0' );
+		\define( 'WPSEO_VERSION', '24.5' );
 
 		$testee = new Yoast_ACF_Analysis_Dependency_Yoast_SEO();
 		$testee->register_notifications();


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the minimum required Yoast SEO version to 24.6.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* NA

Fixes #
