### PR TITLE
GH Actions: enable linting and testing against PHP 8.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
         # And also do a run against "nightly" (the current dev version of PHP).
-        php_version: ['7.2', '7.4', '8.0', '8.2', '8.3']
+        php_version: ['7.2', '7.4', '8.0', '8.4', 'nightly']
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         include:
         - php_version: 7.2
           coverage: true
-        - php_version: 8.3
+        - php_version: 8.4
           coverage: true
 
     name: "Unit Test: PHP ${{ matrix.php_version }}"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Test against PHP 8.4

## Relevant technical choices:

* As the PHP 8.4 builds pass and the PHP 8.4 release has been out for a few months, the builds are not _allowed to fail_.
* Update PHP version on which code coverage is run (high should now be 8.4).


## Test instructions

This PR can be tested by following these steps:

* _N/A_ If the build passes, we're good.