### PR TITLE
Modernize: use trailing comma in multi-line function call

### DIFF
--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -120,7 +120,7 @@ class Actions {
 		$command    = \sprintf(
 			'composer check-cs-warnings -- %s %s',
 			\implode( ' ', \array_map( 'escapeshellarg', $php_files ) ),
-			$extra_args
+			$extra_args,
 		);
 		\system( $command, $exit_code );
 
@@ -196,7 +196,7 @@ class Actions {
 			$files,
 			static function ( $file ) use ( $extension ) {
 				return \substr( $file, ( 0 - \strlen( $extension ) ) ) === $extension;
-			}
+			},
 		);
 	}
 }

--- a/inc/ac-yoast-seo-acf-content-analysis.php
+++ b/inc/ac-yoast-seo-acf-content-analysis.php
@@ -60,7 +60,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			$this->get_blacklist_type(),
 			$this->get_blacklist_name(),
-			$this->get_field_selectors()
+			$this->get_field_selectors(),
 		);
 
 		/**
@@ -80,7 +80,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 			'yoast-acf-analysis/config',
 			[ $configuration ],
 			'YoastSEO ACF 2.4.0',
-			'Yoast\WP\ACF\config'
+			'Yoast\WP\ACF\config',
 		);
 
 		/**
@@ -112,7 +112,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 	protected function register_config_filters() {
 		add_filter(
 			'Yoast\WP\ACF\scraper_config',
-			[ $this, 'filter_scraper_config' ]
+			[ $this, 'filter_scraper_config' ],
 		);
 	}
 
@@ -139,7 +139,7 @@ class AC_Yoast_SEO_ACF_Content_Analysis {
 			'yoast-acf-analysis/headlines',
 			[ [] ],
 			'YoastSEO ACF 2.4.0',
-			'Yoast\WP\ACF\headlines'
+			'Yoast\WP\ACF\headlines',
 		);
 
 		/**

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -50,7 +50,7 @@ class Yoast_ACF_Analysis_Assets {
 				plugins_url( '/js/yoast-acf-analysis.js', AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ),
 				[ 'jquery', 'underscore' ],
 				$this->plugin_data['Version'],
-				true
+				true,
 			);
 
 			wp_localize_script( 'yoast-acf-analysis-post', 'YoastACFAnalysisConfig', $config->to_array() );
@@ -63,7 +63,7 @@ class Yoast_ACF_Analysis_Assets {
 				plugins_url( '/js/yoast-acf-analysis.js', AC_SEO_ACF_ANALYSIS_PLUGIN_FILE ),
 				[ 'jquery', WPSEO_Admin_Asset_Manager::PREFIX . 'term-edit' ],
 				$this->plugin_data['Version'],
-				true
+				true,
 			);
 
 			wp_localize_script( 'yoast-acf-analysis-term', 'YoastACFAnalysisConfig', $config->to_array() );

--- a/inc/configuration/configuration.php
+++ b/inc/configuration/configuration.php
@@ -97,7 +97,7 @@ class Yoast_ACF_Analysis_Configuration {
 			'yoast-acf-analysis/blacklist_type',
 			[ $this->blacklist_type ],
 			'YoastSEO ACF 2.4.0',
-			'Yoast\WP\ACF\blacklist_type'
+			'Yoast\WP\ACF\blacklist_type',
 		);
 
 		/**
@@ -112,7 +112,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$blacklist_type = apply_filters(
 			'Yoast\WP\ACF\blacklist_type',
-			$blacklist_type
+			$blacklist_type,
 		);
 
 		if ( $blacklist_type instanceof Yoast_ACF_Analysis_String_Store ) {
@@ -141,7 +141,7 @@ class Yoast_ACF_Analysis_Configuration {
 			'ysacf_exclude_fields',
 			[ [] ],
 			'YoastSEO ACF 2.0.0',
-			'Yoast\WP\ACF\blacklist_name'
+			'Yoast\WP\ACF\blacklist_name',
 		);
 
 		if ( is_array( $legacy_names ) && ! empty( $legacy_names ) ) {
@@ -162,7 +162,7 @@ class Yoast_ACF_Analysis_Configuration {
 			'yoast-acf-analysis/blacklist_name',
 			[ $this->blacklist_name ],
 			'YoastSEO ACF 2.4.0',
-			'Yoast\WP\ACF\blacklist_name'
+			'Yoast\WP\ACF\blacklist_name',
 		);
 
 		/**
@@ -176,7 +176,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$blacklist_name = apply_filters(
 			'Yoast\WP\ACF\blacklist_name',
-			$blacklist_name
+			$blacklist_name,
 		);
 
 		if ( $blacklist_name instanceof Yoast_ACF_Analysis_String_Store ) {
@@ -213,7 +213,7 @@ class Yoast_ACF_Analysis_Configuration {
 			'yoast-acf-analysis/scraper_config',
 			[ $this->scraper_config ],
 			'YoastSEO ACF 2.4.0',
-			'Yoast\WP\ACF\scraper_config'
+			'Yoast\WP\ACF\scraper_config',
 		);
 
 		/**
@@ -228,7 +228,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$scraper_config = apply_filters(
 			'Yoast\WP\ACF\scraper_config',
-			$scraper_config
+			$scraper_config,
 		);
 
 		if ( is_array( $scraper_config ) ) {
@@ -256,7 +256,7 @@ class Yoast_ACF_Analysis_Configuration {
 			'yoast-acf-analysis/refresh_rate',
 			[ $this->refresh_rate ],
 			'YoastSEO ACF 2.4.0',
-			'Yoast\WP\ACF\refresh_rate'
+			'Yoast\WP\ACF\refresh_rate',
 		);
 
 		/**
@@ -295,7 +295,7 @@ class Yoast_ACF_Analysis_Configuration {
 			'yoast-acf-analysis/field_selectors',
 			[ $this->field_selectors ],
 			'YoastSEO ACF 2.4.0',
-			'Yoast\WP\ACF\field_selectors'
+			'Yoast\WP\ACF\field_selectors',
 		);
 
 		/**
@@ -314,7 +314,7 @@ class Yoast_ACF_Analysis_Configuration {
 		 */
 		$field_selectors = apply_filters(
 			'Yoast\WP\ACF\field_selectors',
-			$field_selectors
+			$field_selectors,
 		);
 
 		if ( $field_selectors instanceof Yoast_ACF_Analysis_String_Store ) {
@@ -345,7 +345,7 @@ class Yoast_ACF_Analysis_Configuration {
 			'yoast-acf-analysis/field_order',
 			[ [] ],
 			'YoastSEO ACF 2.4.0',
-			'Yoast\WP\ACF\field_order'
+			'Yoast\WP\ACF\field_order',
 		);
 
 		/**

--- a/inc/dependencies/dependency-acf.php
+++ b/inc/dependencies/dependency-acf.php
@@ -50,7 +50,7 @@ final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Depe
 				. sprintf(
 					/* translators: %1$s: Advanced Custom Fields */
 					esc_html__( 'Install latest %1$s', 'acf-content-analysis-for-yoast-seo' ),
-					'Advanced Custom Fields'
+					'Advanced Custom Fields',
 				)
 				. '</h4>'
 				. '<div class="notice-yoast-content">'
@@ -59,12 +59,12 @@ final class Yoast_ACF_Analysis_Dependency_ACF implements Yoast_ACF_Analysis_Depe
 						/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO, %2$s resolves to Advanced Custom Fields, %3$s resolves to the minimum required ACF version. */
 						esc_html__(
 							'%1$s requires %2$s (free or pro) %3$s or higher to be installed and activated.',
-							'acf-content-analysis-for-yoast-seo'
+							'acf-content-analysis-for-yoast-seo',
 						),
 						'ACF Content Analysis for Yoast SEO',
 						'Advanced Custom Fields',
 						// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: This is a hardcoded value.
-						self::MINIMAL_REQUIRED_ACF_VERSION
+						self::MINIMAL_REQUIRED_ACF_VERSION,
 					)
 					. '</p>'
 				. '</div>'

--- a/inc/dependencies/dependency-yoast-seo.php
+++ b/inc/dependencies/dependency-yoast-seo.php
@@ -57,7 +57,7 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 				. sprintf(
 					/* translators: %1$s: Yoast SEO */
 					esc_html__( 'Install %1$s', 'acf-content-analysis-for-yoast-seo' ),
-					'Yoast SEO'
+					'Yoast SEO',
 				)
 				. '</h4>'
 				. '<div class="notice-yoast-content">'
@@ -66,10 +66,10 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 						/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO, %2$s resolves to Yoast SEO. */
 						esc_html__(
 							'%1$s requires %2$s to be installed and activated.',
-							'acf-content-analysis-for-yoast-seo'
+							'acf-content-analysis-for-yoast-seo',
 						),
 						'ACF Content Analysis for Yoast SEO',
-						'Yoast SEO'
+						'Yoast SEO',
 					)
 					. '</p>'
 				. '</div>'
@@ -89,7 +89,7 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 				. sprintf(
 					/* translators: %1$s: Yoast SEO */
 					esc_html__( 'Update %1$s', 'acf-content-analysis-for-yoast-seo' ),
-					'Yoast SEO'
+					'Yoast SEO',
 				)
 				. '</h4>'
 				. '<div class="notice-yoast-content">'
@@ -98,10 +98,10 @@ final class Yoast_ACF_Analysis_Dependency_Yoast_SEO implements Yoast_ACF_Analysi
 						/* translators: %1$s resolves to Yoast SEO, %2$s resolves to ACF Content Analysis for Yoast SEO */
 						esc_html__(
 							'Please upgrade the %1$s plugin to the latest version to allow the %2$s module to work.',
-							'acf-content-analysis-for-yoast-seo'
+							'acf-content-analysis-for-yoast-seo',
 						),
 						'Yoast SEO',
-						'ACF Content Analysis for Yoast SEO'
+						'ACF Content Analysis for Yoast SEO',
 					)
 					. '</p>'
 				. '</div>'

--- a/tests/Unit/Assets_Test.php
+++ b/tests/Unit/Assets_Test.php
@@ -29,7 +29,7 @@ final class Assets_Test extends TestCase {
 			->andReturn(
 				[
 					'Version' => '2.0.0',
-				]
+				],
 			);
 
 		$testee = new Yoast_ACF_Analysis_Assets();

--- a/tests/Unit/Configuration/Configuration_Test.php
+++ b/tests/Unit/Configuration/Configuration_Test.php
@@ -26,7 +26,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			new Yoast_ACF_Analysis_String_Store(),
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		$this->assertSame(
@@ -41,7 +41,7 @@ final class Configuration_Test extends TestCase {
 				'fieldOrder'     => [],
 				'debug'          => false,
 			],
-			$configuration->to_array()
+			$configuration->to_array(),
 		);
 
 		$this->assertSame( 1, Filters\applied( 'acf/get_info' ) );
@@ -59,7 +59,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			new Yoast_ACF_Analysis_String_Store(),
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 		$config        = $configuration->to_array();
 
@@ -78,7 +78,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			$blacklist_type,
 			new Yoast_ACF_Analysis_String_Store(),
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		$blacklist_type2 = new Yoast_ACF_Analysis_String_Store();
@@ -103,7 +103,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			$store,
 			new Yoast_ACF_Analysis_String_Store(),
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_type' )
@@ -126,7 +126,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			$blacklist_name,
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		$blacklist_name2 = new Yoast_ACF_Analysis_String_Store();
@@ -151,7 +151,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			$blacklist_name,
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		Filters\expectApplied( 'ysacf_exclude_fields' )
@@ -188,7 +188,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			$blacklist_name,
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		Filters\expectApplied( 'ysacf_exclude_fields' )
@@ -218,7 +218,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			$store,
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\blacklist_name' )
@@ -241,7 +241,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			$blacklist,
 			new Yoast_ACF_Analysis_String_Store(),
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\scraper_config' )
@@ -263,7 +263,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			$blacklist,
 			new Yoast_ACF_Analysis_String_Store(),
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\scraper_config' )
@@ -288,7 +288,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			new Yoast_ACF_Analysis_String_Store(),
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		$this->assertSame( 9999, $configuration->get_refresh_rate() );
@@ -308,7 +308,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			new Yoast_ACF_Analysis_String_Store(),
-			new Yoast_ACF_Analysis_String_Store()
+			new Yoast_ACF_Analysis_String_Store(),
 		);
 
 		$this->assertSame( 200, $configuration->get_refresh_rate() );
@@ -326,7 +326,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			new Yoast_ACF_Analysis_String_Store(),
-			$field_selector
+			$field_selector,
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\field_selectors' )
@@ -349,7 +349,7 @@ final class Configuration_Test extends TestCase {
 		$configuration = new Yoast_ACF_Analysis_Configuration(
 			new Yoast_ACF_Analysis_String_Store(),
 			new Yoast_ACF_Analysis_String_Store(),
-			$store
+			$store,
 		);
 
 		Filters\expectApplied( 'Yoast\WP\ACF\field_selectors' )

--- a/tests/Unit/Registry_Test.php
+++ b/tests/Unit/Registry_Test.php
@@ -34,8 +34,8 @@ final class Registry_Test extends TestCase {
 			new Yoast_ACF_Analysis_Configuration(
 				new Yoast_ACF_Analysis_String_Store(),
 				new Yoast_ACF_Analysis_String_Store(),
-				new Yoast_ACF_Analysis_String_Store()
-			)
+				new Yoast_ACF_Analysis_String_Store(),
+			),
 		);
 
 		$this->assertSame( $first, $second );

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -59,7 +59,7 @@ function yoast_acf_report_missing_acf() {
 			. sprintf(
 				/* translators: %1$s: ACF Content Analysis for Yoast SEO */
 				esc_html__( 'Unable to load %1$s', 'acf-content-analysis-for-yoast-seo' ),
-				'ACF Content Analysis for Yoast SEO'
+				'ACF Content Analysis for Yoast SEO',
 			)
 			. '</h4>'
 			. '<div class="notice-yoast-content">'
@@ -68,9 +68,9 @@ function yoast_acf_report_missing_acf() {
 					/* translators: %1$s resolves to ACF Content Analysis for Yoast SEO */
 					esc_html__(
 						'%1$s could not be loaded because of missing files.',
-						'acf-content-analysis-for-yoast-seo'
+						'acf-content-analysis-for-yoast-seo',
 					),
-					'ACF Content Analysis for Yoast SEO'
+					'ACF Content Analysis for Yoast SEO',
 				)
 				. '</p>'
 			. '</div>'


### PR DESCRIPTION

## Summary

This PR can be summarized in the following changelog entry:

* Code modernization

## Relevant technical choices:

Since PHP 7.3, PHP allows for trailing commas in function calls.

Similar to trailing commas in multi-line arrays, having a comma after the last parameter in a multi-line function call will make the diff smaller if a new parameter is added at a later point in time, allowing reviewers to focus on what's actually changed.

For a single-line function call, no such advantage can be gained.

As this codebase has dropped support for PHP < 7.4 by now, we can apply this modernization in all multi-line function calls.

Ref:
* https://wiki.php.net/rfc/trailing-comma-function-calls


## Test instructions

This PR can be tested by following these steps:

* _N/A_