### PR TITLE
Modernize: use null coalesce equals operator

### DIFF
--- a/inc/facade.php
+++ b/inc/facade.php
@@ -27,9 +27,7 @@ class Yoast_ACF_Analysis_Facade {
 	public static function get_registry() {
 		static $registry = null;
 
-		if ( $registry === null ) {
-			$registry = new Yoast_ACF_Analysis_Registry();
-		}
+		$registry ??= new Yoast_ACF_Analysis_Registry();
 
 		return $registry;
 	}


### PR DESCRIPTION

## Summary

This PR can be summarized in the following changelog entry:

* Code modernization

## Relevant technical choices:

Use null coalesce equals operator as allowed and available since PHP 7.4.


## Test instructions

This PR can be tested by following these steps:

* _N/A_