### PR TITLE
GH Actions: enable linting and testing against PHP 8.5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,9 @@ jobs:
       matrix:
         # Lint against the highest/lowest supported versions of each PHP major.
         # And also do a run against "nightly" (the current dev version of PHP).
-        php_version: ['7.4', '8.0', '8.4', 'nightly']
+        php_version: ['7.4', '8.0', '8.5', 'nightly']
+
+    continue-on-error: ${{ matrix.php_version == 'nightly' }}
 
     name: "Lint: PHP ${{ matrix.php_version }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         include:
         - php_version: 7.4
           coverage: true
-        - php_version: 8.4
+        - php_version: 8.5
           coverage: true
 
     name: "Unit Test: PHP ${{ matrix.php_version }}"


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Confirmed compatibility with PHP 8.5. Please report any issues you may still see.

## Relevant technical choices:

* As the PHP 8.5 builds pass and PHP 8.5 has been released a little while back, the builds are not _allowed to fail_, though linting against PHP "nightly" _may_ fail.
* Update PHP version on which code coverage is run (high should now be 8.5).


## Test instructions

This PR can be tested by following these steps:

* _N/A_