### PR TITLE
Sets the minimum supported WordPress version to 6.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === ACF Content Analysis for Yoast SEO ===
 Contributors: yoast, angrycreative, kraftner, marcusforsberg, viktorfroberg, joostdevalk, atimmer, jipmoors, theorboman
 Tags: Yoast, SEO, ACF, Advanced Custom Fields, analysis, Search Engine Optimization
-Requires at least: 6.8
+Requires at least: 6.9
 Tested up to: 7.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html

--- a/yoast-acf-analysis.php
+++ b/yoast-acf-analysis.php
@@ -14,7 +14,7 @@
  * License:     GPL v3
  * Text Domain: acf-content-analysis-for-yoast-seo
  * Domain Path: /languages/
- * Requires at least: 6.8
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  */
 


### PR DESCRIPTION
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the minimum supported WordPress version to 6.9.

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Verify that `yoast-acf-analysis.php` and `readme.txt` state `Requires at least: 6.9`.
* On a site running WordPress 6.9 or newer, verify that the plugin activates and works as before.

Refs Yoast/wordpress-seo#23529.
Previous iteration: Yoast/yoast-acf-analysis#414.

Fixes #
